### PR TITLE
fix: direct-mail template codegen collision

### DIFF
--- a/registry/nodes/direct-mail/1.0.0/template.ts
+++ b/registry/nodes/direct-mail/1.0.0/template.ts
@@ -19,7 +19,7 @@ export default async function (ctx) {
     return btoa(String.fromCharCode(...new Uint8Array(signature)))
   }
 
-  const params: Record<string, string> = {
+  const reqParams: Record<string, string> = {
     Action: 'SingleSendMail',
     Format: 'JSON',
     Version: '2015-11-23',
@@ -36,19 +36,19 @@ export default async function (ctx) {
     RegionId: ctx.config.regionId,
   }
 
-  if (ctx.config.htmlBody) params.HtmlBody = ctx.config.htmlBody
-  if (ctx.config.textBody) params.TextBody = ctx.config.textBody
+  if (ctx.config.htmlBody) reqParams.HtmlBody = ctx.config.htmlBody
+  if (ctx.config.textBody) reqParams.TextBody = ctx.config.textBody
 
-  const sortedKeys = Object.keys(params).sort()
+  const sortedKeys = Object.keys(reqParams).sort()
   const canonicalQuery = sortedKeys
-    .map((k) => `${percentEncode(k)}=${percentEncode(params[k])}`)
+    .map((k) => `${percentEncode(k)}=${percentEncode(reqParams[k])}`)
     .join('&')
 
   const stringToSign = `POST&${percentEncode('/')}&${percentEncode(canonicalQuery)}`
   const signature = await hmacSha1(accessKeySecret + '&', stringToSign)
-  params.Signature = signature
+  reqParams.Signature = signature
 
-  const body = Object.entries(params)
+  const body = Object.entries(reqParams)
     .map(([k, v]) => `${encodeURIComponent(k)}=${encodeURIComponent(v)}`)
     .join('&')
 

--- a/registry/nodes/google-gemini/1.0.0/node.json
+++ b/registry/nodes/google-gemini/1.0.0/node.json
@@ -3,12 +3,7 @@
   "name": "Google Gemini",
   "category": "AI",
   "icon": "https://raw.githubusercontent.com/awaitstep/awaitstep/main/registry/nodes/google-gemini/icon.svg",
-  "tags": [
-    "google",
-    "gemini",
-    "ai",
-    "llm"
-  ],
+  "tags": ["google", "gemini", "ai", "llm"],
   "author": "awaitstep",
   "license": "Apache-2.0",
   "configSchema": {
@@ -17,11 +12,7 @@
       "label": "Action",
       "required": true,
       "description": "The Google Gemini API action to perform.",
-      "options": [
-        "Generate Content",
-        "Create Embedding",
-        "Count Tokens"
-      ]
+      "options": ["Generate Content", "Create Embedding", "Count Tokens"]
     },
     "model": {
       "type": "string",
@@ -68,9 +59,7 @@
       "description": "Full API response object"
     }
   },
-  "providers": [
-    "cloudflare"
-  ],
+  "providers": ["cloudflare"],
   "runtime": {
     "defaultRetries": 3,
     "defaultTimeout": "60 seconds"

--- a/registry/nodes/google-gemini/1.0.1/node.json
+++ b/registry/nodes/google-gemini/1.0.1/node.json
@@ -3,14 +3,7 @@
   "name": "Google Gemini",
   "category": "AI",
   "icon": "https://raw.githubusercontent.com/awaitstep/awaitstep/main/registry/nodes/google-gemini/icon.svg",
-  "tags": [
-    "google",
-    "gemini",
-    "ai",
-    "llm",
-    "embedding",
-    "search"
-  ],
+  "tags": ["google", "gemini", "ai", "llm", "embedding", "search"],
   "author": "awaitstep",
   "license": "Apache-2.0",
   "configSchema": {
@@ -19,13 +12,7 @@
       "label": "Action",
       "required": true,
       "description": "The Google Gemini API action to perform.",
-      "options": [
-        "Generate Content",
-        "Generate JSON",
-        "Embed Text",
-        "Search Web",
-        "Count Tokens"
-      ]
+      "options": ["Generate Content", "Generate JSON", "Embed Text", "Search Web", "Count Tokens"]
     },
     "model": {
       "type": "string",
@@ -77,9 +64,7 @@
       "description": "Full API response object"
     }
   },
-  "providers": [
-    "cloudflare"
-  ],
+  "providers": ["cloudflare"],
   "runtime": {
     "defaultRetries": 3,
     "defaultTimeout": "60 seconds"


### PR DESCRIPTION
## Summary
- Rename `params` to `reqParams` in direct-mail node template to avoid variable name collision with the generated worker's `execute(env, params)` signature
- Fix prettier formatting in google-gemini node.json files