### PR TITLE
ci: format node.json files in registry index build

### DIFF
--- a/.github/workflows/registry-index.yml
+++ b/.github/workflows/registry-index.yml
@@ -29,7 +29,7 @@ jobs:
       - run: pnpm install --frozen-lockfile
 
       - name: Build registry index
-        run: pnpm --filter @awaitstep/ir build && npx tsx registry/scripts/build-index.ts && npx prettier --write registry/index.json
+        run: pnpm --filter @awaitstep/ir build && npx tsx registry/scripts/build-index.ts && npx prettier --write registry/index.json registry/nodes/*/*/node.json
 
       - name: Check for changes
         id: diff


### PR DESCRIPTION
## Summary
- Add `registry/nodes/*/*/node.json` to the prettier --write step in the registry index CI workflow
- Prevents unformatted node.json files from being committed by the automation