### PR TITLE
fix: inline code editor bypassing debounce

### DIFF
--- a/apps/web/src/components/ui/code-editor.tsx
+++ b/apps/web/src/components/ui/code-editor.tsx
@@ -210,8 +210,8 @@ export function CodeEditor({
         <MonacoEditor
           height={height}
           language={language}
-          value={value}
-          onChange={(v) => onChangeRef.current(v ?? '')}
+          value={displayValue}
+          onChange={(v) => handleChange(v ?? '')}
           theme="vs-dark"
           beforeMount={injectTypes}
           options={editorOptions}


### PR DESCRIPTION
## Summary
- Inline Monaco editor was using `value` and `onChangeRef.current` directly, bypassing the debounce logic
- Now uses `displayValue` and `handleChange` like the fullscreen editor already does
- Fixes codegen producing garbage output when typing in JSON fields (e.g. headers)