### PR TITLE
feat: HTTP query params and JSON field validation

### DIFF
--- a/apps/web/src/components/canvas/dynamic-fields.tsx
+++ b/apps/web/src/components/canvas/dynamic-fields.tsx
@@ -184,10 +184,15 @@ function FieldRenderer({ field, value, onChange }: DynamicFieldProps) {
         <CodeEditor
           value={jsonValue}
           onChange={(v) => {
+            if (!v) {
+              onChange(undefined)
+              return
+            }
             try {
-              onChange(v ? JSON.parse(v) : undefined)
+              onChange(JSON.parse(v))
             } catch {
-              onChange(v)
+              // Don't propagate invalid JSON to the store —
+              // the editor holds local state via debounce
             }
           }}
           debounceMs={300}

--- a/packages/ir/src/bundled-nodes/http-request.ts
+++ b/packages/ir/src/bundled-nodes/http-request.ts
@@ -28,6 +28,11 @@ export const httpRequestDefinition: NodeDefinition = {
       label: 'Headers',
       description: 'JSON object of request headers.',
     },
+    queryParams: {
+      type: 'json',
+      label: 'Query Parameters',
+      description: 'JSON object of URL query parameters.',
+    },
     body: {
       type: 'code',
       label: 'Body',

--- a/packages/provider-cloudflare/src/__tests__/codegen/generators/http.test.ts
+++ b/packages/provider-cloudflare/src/__tests__/codegen/generators/http.test.ts
@@ -195,4 +195,63 @@ describe('generateHttp', () => {
     )
     expect(code).toContain('`${env.PREFIX}-${env.SUFFIX}`')
   })
+
+  it('appends query params using URL and searchParams', () => {
+    const code = generateHttp(
+      makeNode({
+        data: {
+          url: 'https://api.example.com/data',
+          method: 'GET',
+          queryParams: { page: '1', limit: '10' },
+        },
+      }),
+    )
+    expect(code).toContain('new URL("https://api.example.com/data")')
+    expect(code).toContain('url.searchParams.set("page", "1")')
+    expect(code).toContain('url.searchParams.set("limit", "10")')
+    expect(code).toContain('await fetch(url)')
+  })
+
+  it('supports expressions in query param values', () => {
+    const code = generateHttp(
+      makeNode({
+        data: {
+          url: 'https://api.example.com/data',
+          method: 'GET',
+          queryParams: { cursor: '${state.nextCursor}' },
+        },
+      }),
+    )
+    expect(code).toContain('url.searchParams.set("cursor", `${state.nextCursor}`)')
+  })
+
+  it('omits query params when empty object', () => {
+    const code = generateHttp(
+      makeNode({
+        data: { url: 'https://api.example.com/data', method: 'GET', queryParams: {} },
+      }),
+    )
+    expect(code).not.toContain('searchParams')
+    expect(code).not.toContain('new URL')
+  })
+
+  it('combines query params with headers and body', () => {
+    const code = generateHttp(
+      makeNode({
+        data: {
+          url: 'https://api.example.com/data',
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          queryParams: { token: 'abc' },
+          body: 'JSON.stringify({ key: "value" })',
+        },
+      }),
+    )
+    expect(code).toContain('new URL("https://api.example.com/data")')
+    expect(code).toContain('url.searchParams.set("token", "abc")')
+    expect(code).toContain('await fetch(url, {')
+    expect(code).toContain('method: "POST"')
+    expect(code).toContain('"Content-Type": "application/json"')
+    expect(code).toContain('body: JSON.stringify({ key: "value" })')
+  })
 })

--- a/packages/provider-cloudflare/src/codegen/generators/http.ts
+++ b/packages/provider-cloudflare/src/codegen/generators/http.ts
@@ -5,8 +5,17 @@ import { generateStepConfig } from './config.js'
 export function generateHttp(node: WorkflowNode): string {
   const method = String(node.data.method ?? 'GET')
   const url = String(node.data.url ?? '')
-  const headers = node.data.headers as Record<string, string> | undefined
+  const rawHeaders = node.data.headers
+  const headers =
+    rawHeaders && typeof rawHeaders === 'object' && !Array.isArray(rawHeaders)
+      ? (rawHeaders as Record<string, string>)
+      : undefined
   const body = node.data.body as string | undefined
+  const rawQueryParams = node.data.queryParams
+  const queryParams =
+    rawQueryParams && typeof rawQueryParams === 'object' && !Array.isArray(rawQueryParams)
+      ? (rawQueryParams as Record<string, string>)
+      : undefined
 
   const config = generateStepConfig(node.config)
   const configArg = config ? `, ${config}` : ''
@@ -24,13 +33,30 @@ export function generateHttp(node: WorkflowNode): string {
     fetchOptions.push(`body: ${body}`)
   }
 
+  const hasQueryParams = queryParams && Object.keys(queryParams).length > 0
   const needsOptions = method !== 'GET' || fetchOptions.length > 1
   const fetchOpts = needsOptions ? `, { ${fetchOptions.join(', ')} }` : ''
-  const urlLiteral = toStringLiteral(url)
+
+  const lines: string[] = []
+
+  if (hasQueryParams) {
+    const urlLiteral = toStringLiteral(url)
+    lines.push(`const url = new URL(${urlLiteral});`)
+    for (const [k, v] of Object.entries(queryParams)) {
+      lines.push(`url.searchParams.set("${k}", ${toStringLiteral(v)});`)
+    }
+    lines.push(`const response = await fetch(url${fetchOpts});`)
+  } else {
+    const urlLiteral = toStringLiteral(url)
+    lines.push(`const response = await fetch(${urlLiteral}${fetchOpts});`)
+  }
+
+  lines.push('return response.json();')
+
+  const bodyCode = lines.map((l) => `  ${l}`).join('\n')
 
   return `const ${varName(node.id)} = await step.do("${escName(node.name)}"${configArg}, async () => {
-  const response = await fetch(${urlLiteral}${fetchOpts});
-  return response.json();
+${bodyCode}
 });`
 }
 


### PR DESCRIPTION
## Summary
- Add `queryParams` field to HTTP Request node — generates `new URL()` + `searchParams.set()` for clean query string handling
- Add type guards in HTTP codegen so `headers` and `queryParams` must be objects (not strings from invalid JSON)
- Fix `DynamicFields` JSON handler to only propagate valid parsed JSON to the store — invalid JSON stays local in the editor

## Test plan
- [ ] 4 new tests for queryParams codegen (basic, expressions, empty, combined with headers/body)
- [ ] Existing 241 provider-cloudflare tests pass
- [ ] Type in a JSON field mid-edit — codegen should not produce garbage