### PR TITLE
fix: use always-bump-patch versioning and override next release to 1.4.6

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -6,6 +6,8 @@
       "component": "awaitstep",
       "changelog-path": "CHANGELOG.md",
       "include-component-in-tag": false,
+      "versioning": "always-bump-patch",
+      "release-as": "1.4.6",
       "prerelease": true,
       "prerelease-type": "beta",
       "exclude-paths": ["apps/www", "apps/docs"],


### PR DESCRIPTION
## Summary
- Add `"versioning": "always-bump-patch"` so `feat:` commits bump patch instead of minor — only `BREAKING CHANGE:` bumps minor/major
- Add `"release-as": "1.4.6"` to override the current 1.5.0-beta.0 release back to 1.4.6-beta.0 (one-time, remove after release)