### PR TITLE
fix: handle non-string values in HTTP codegen JSON fields

### DIFF
--- a/packages/provider-cloudflare/src/codegen/generators/http.ts
+++ b/packages/provider-cloudflare/src/codegen/generators/http.ts
@@ -60,7 +60,8 @@ ${bodyCode}
 });`
 }
 
-function toStringLiteral(value: string): string {
+function toStringLiteral(value: unknown): string {
+  if (typeof value !== 'string') return JSON.stringify(value)
   const hasExpression = /\$\{.*?\}/.test(value)
   const hasNewline = /\r?\n/.test(value)
 


### PR DESCRIPTION
## Summary
- `toStringLiteral` now accepts `unknown` and falls back to `JSON.stringify` for non-string values
- Fixes `e.replace is not a function` error when JSON header/queryParam fields contain numbers, booleans, or objects