### PR TITLE
fix: auto-wrap HTTP body with JSON.stringify for non-string expressions

### DIFF
--- a/packages/provider-cloudflare/src/__tests__/codegen/generators/http.test.ts
+++ b/packages/provider-cloudflare/src/__tests__/codegen/generators/http.test.ts
@@ -62,7 +62,7 @@ describe('generateHttp', () => {
     expect(code).toContain('"Accept": "application/json"')
   })
 
-  it('emits body as raw JS expression', () => {
+  it('passes through body with JSON.stringify already applied', () => {
     const code = generateHttp(
       makeNode({
         data: {
@@ -73,6 +73,34 @@ describe('generateHttp', () => {
       }),
     )
     expect(code).toContain('body: JSON.stringify({ key: "value" })')
+    expect(code).not.toContain('body: JSON.stringify(JSON.stringify')
+  })
+
+  it('auto-wraps object body with JSON.stringify', () => {
+    const code = generateHttp(
+      makeNode({
+        data: {
+          url: 'https://api.example.com/data',
+          method: 'POST',
+          body: '{ key: "value" }',
+        },
+      }),
+    )
+    expect(code).toContain('body: JSON.stringify({ key: "value" })')
+  })
+
+  it('passes through string literal body without wrapping', () => {
+    const code = generateHttp(
+      makeNode({
+        data: {
+          url: 'https://api.example.com/data',
+          method: 'POST',
+          body: '"plain text body"',
+        },
+      }),
+    )
+    expect(code).toContain('body: "plain text body"')
+    expect(code).not.toContain('JSON.stringify')
   })
 
   it('uses template literals for URLs with expressions', () => {

--- a/packages/provider-cloudflare/src/codegen/generators/http.ts
+++ b/packages/provider-cloudflare/src/codegen/generators/http.ts
@@ -30,7 +30,14 @@ export function generateHttp(node: WorkflowNode): string {
   }
 
   if (body) {
-    fetchOptions.push(`body: ${body}`)
+    const trimmed = body.trim()
+    const isAlreadyStringified = trimmed.startsWith('JSON.stringify')
+    const isStringLiteral = /^["'`]/.test(trimmed)
+    if (isAlreadyStringified || isStringLiteral) {
+      fetchOptions.push(`body: ${body}`)
+    } else {
+      fetchOptions.push(`body: JSON.stringify(${body})`)
+    }
   }
 
   const hasQueryParams = queryParams && Object.keys(queryParams).length > 0


### PR DESCRIPTION
## Summary
- HTTP body expressions like `{ key: "value" }` are now auto-wrapped with `JSON.stringify()` so fetch receives a string instead of `[object Object]`
- String literals (`"text"`, `` `template` ``) and already-wrapped `JSON.stringify(...)` pass through unchanged