### PR TITLE
fix: correct DirectMail percentEncode to match Alibaba Cloud RFC 3986 spec

### DIFF
--- a/registry/nodes/direct-mail/1.0.0/template.ts
+++ b/registry/nodes/direct-mail/1.0.0/template.ts
@@ -3,7 +3,12 @@ export default async function (ctx) {
   const accessKeySecret = ctx.env.ALICLOUD_ACCESS_KEY_SECRET
 
   function percentEncode(str: string): string {
-    return encodeURIComponent(str).replace(/\+/g, '%20').replace(/\*/g, '%2A').replace(/~/g, '%7E')
+    return encodeURIComponent(str)
+      .replace(/!/g, '%21')
+      .replace(/'/g, '%27')
+      .replace(/\(/g, '%28')
+      .replace(/\)/g, '%29')
+      .replace(/\*/g, '%2A')
   }
 
   async function hmacSha1(key: string, data: string): Promise<string> {


### PR DESCRIPTION
## Summary
- Encode `!`, `'`, `(`, `)` which `encodeURIComponent` skips but Alibaba's API requires
- Remove incorrect `~` encoding (`~` is unreserved in RFC 3986)
- Remove no-op `+` replacement (`encodeURIComponent` already encodes `+` as `%2B`)
- Fixes `SignatureDoesNotMatch` errors when HTML body contains these characters