### PR TITLE
fix: recursive JSON codegen, DirectMail signing, and always-bump-patch versioning

### DIFF
--- a/packages/provider-cloudflare/src/__tests__/codegen/generators/custom.test.ts
+++ b/packages/provider-cloudflare/src/__tests__/codegen/generators/custom.test.ts
@@ -59,9 +59,16 @@ describe('toJsLiteral', () => {
     expect(toJsLiteral(undefined)).toBe('null')
   })
 
-  it('converts objects/arrays to JSON', () => {
-    expect(toJsLiteral({ a: 1 })).toBe('{"a":1}')
-    expect(toJsLiteral([1, 2])).toBe('[1,2]')
+  it('converts objects/arrays to JS literals', () => {
+    expect(toJsLiteral({ a: 1 })).toBe('{ "a": 1 }')
+    expect(toJsLiteral([1, 2])).toBe('[1, 2]')
+  })
+
+  it('resolves env expressions in nested objects', () => {
+    expect(toJsLiteral({ token: '${env.TOKEN}' })).toBe('{ "token": `${env.TOKEN}` }')
+    expect(toJsLiteral({ nested: { key: '${env.KEY}' } })).toBe(
+      '{ "nested": { "key": `${env.KEY}` } }',
+    )
   })
 })
 

--- a/packages/provider-cloudflare/src/codegen/generators/custom.ts
+++ b/packages/provider-cloudflare/src/codegen/generators/custom.ts
@@ -39,6 +39,15 @@ export function toJsLiteral(value: unknown): string {
     return JSON.stringify(value)
   }
   if (typeof value === 'number' || typeof value === 'boolean') return String(value)
+  if (Array.isArray(value)) {
+    return `[${value.map((v) => toJsLiteral(v)).join(', ')}]`
+  }
+  if (typeof value === 'object') {
+    const entries = Object.entries(value as Record<string, unknown>)
+      .map(([k, v]) => `${JSON.stringify(k)}: ${toJsLiteral(v)}`)
+      .join(', ')
+    return `{ ${entries} }`
+  }
   return JSON.stringify(value)
 }
 

--- a/packages/provider-cloudflare/src/codegen/generators/http.ts
+++ b/packages/provider-cloudflare/src/codegen/generators/http.ts
@@ -60,7 +60,8 @@ ${bodyCode}
 });`
 }
 
-function toStringLiteral(value: string): string {
+function toStringLiteral(value: unknown): string {
+  if (typeof value !== 'string') return JSON.stringify(value)
   const hasExpression = /\$\{.*?\}/.test(value)
   const hasNewline = /\r?\n/.test(value)
 

--- a/packages/provider-cloudflare/src/codegen/generators/http.ts
+++ b/packages/provider-cloudflare/src/codegen/generators/http.ts
@@ -24,7 +24,7 @@ export function generateHttp(node: WorkflowNode): string {
 
   if (headers && Object.keys(headers).length > 0) {
     const headerEntries = Object.entries(headers)
-      .map(([k, v]) => `"${k}": ${toStringLiteral(v)}`)
+      .map(([k, v]) => `"${k}": ${toJsLiteral(v)}`)
       .join(', ')
     fetchOptions.push(`headers: { ${headerEntries} }`)
   }
@@ -40,14 +40,14 @@ export function generateHttp(node: WorkflowNode): string {
   const lines: string[] = []
 
   if (hasQueryParams) {
-    const urlLiteral = toStringLiteral(url)
+    const urlLiteral = toJsLiteral(url)
     lines.push(`const url = new URL(${urlLiteral});`)
     for (const [k, v] of Object.entries(queryParams)) {
-      lines.push(`url.searchParams.set("${k}", ${toStringLiteral(v)});`)
+      lines.push(`url.searchParams.set("${k}", ${toJsLiteral(v)});`)
     }
     lines.push(`const response = await fetch(url${fetchOpts});`)
   } else {
-    const urlLiteral = toStringLiteral(url)
+    const urlLiteral = toJsLiteral(url)
     lines.push(`const response = await fetch(${urlLiteral}${fetchOpts});`)
   }
 
@@ -60,15 +60,26 @@ ${bodyCode}
 });`
 }
 
-function toStringLiteral(value: unknown): string {
-  if (typeof value !== 'string') return JSON.stringify(value)
-  const hasExpression = /\$\{.*?\}/.test(value)
-  const hasNewline = /\r?\n/.test(value)
-
-  if (hasExpression || hasNewline) {
-    // Template literal: escape backticks and literal backslashes
-    const escaped = value.replace(/\\/g, '\\\\').replace(/`/g, '\\`')
-    return '`' + escaped + '`'
+function toJsLiteral(value: unknown): string {
+  if (value === null || value === undefined) return 'null'
+  if (typeof value === 'number' || typeof value === 'boolean') return String(value)
+  if (typeof value === 'string') {
+    const hasExpression = /\$\{.*?\}/.test(value)
+    const hasNewline = /\r?\n/.test(value)
+    if (hasExpression || hasNewline) {
+      const escaped = value.replace(/\\/g, '\\\\').replace(/`/g, '\\`')
+      return '`' + escaped + '`'
+    }
+    return `"${value.replace(/\\/g, '\\\\').replace(/"/g, '\\"')}"`
   }
-  return `"${value.replace(/\\/g, '\\\\').replace(/"/g, '\\"')}"`
+  if (Array.isArray(value)) {
+    return `[${value.map((v) => toJsLiteral(v)).join(', ')}]`
+  }
+  if (typeof value === 'object') {
+    const entries = Object.entries(value as Record<string, unknown>)
+      .map(([k, v]) => `"${k}": ${toJsLiteral(v)}`)
+      .join(', ')
+    return `{ ${entries} }`
+  }
+  return JSON.stringify(value)
 }

--- a/registry/nodes/direct-mail/1.0.0/template.ts
+++ b/registry/nodes/direct-mail/1.0.0/template.ts
@@ -3,7 +3,12 @@ export default async function (ctx) {
   const accessKeySecret = ctx.env.ALICLOUD_ACCESS_KEY_SECRET
 
   function percentEncode(str: string): string {
-    return encodeURIComponent(str).replace(/\+/g, '%20').replace(/\*/g, '%2A').replace(/~/g, '%7E')
+    return encodeURIComponent(str)
+      .replace(/!/g, '%21')
+      .replace(/'/g, '%27')
+      .replace(/\(/g, '%28')
+      .replace(/\)/g, '%29')
+      .replace(/\*/g, '%2A')
   }
 
   async function hmacSha1(key: string, data: string): Promise<string> {

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -6,6 +6,8 @@
       "component": "awaitstep",
       "changelog-path": "CHANGELOG.md",
       "include-component-in-tag": false,
+      "versioning": "always-bump-patch",
+      "release-as": "1.4.6",
       "prerelease": true,
       "prerelease-type": "beta",
       "exclude-paths": ["apps/www", "apps/docs"],


### PR DESCRIPTION
## Summary
- Recursively resolve `${env.X}` expressions in nested JSON fields for both HTTP and custom node codegen
- Fix DirectMail `percentEncode` to match Alibaba Cloud RFC 3986 spec (encode `!`, `'`, `(`, `)`, remove incorrect `~` encoding)
- Handle non-string values (numbers, booleans, objects) in HTTP header/queryParam codegen
- Switch release-please to `always-bump-patch` versioning and override next release to 1.4.6