### PR TITLE
fix: canvas loading skeleton

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -7,3 +7,4 @@ packages/db/drizzle
 packages/email/src/templates/__generated__
 CHANGELOG.md
 .github/dependabot.yml
+.claude/worktrees

--- a/apps/web/src/components/canvas/canvas-skeleton.tsx
+++ b/apps/web/src/components/canvas/canvas-skeleton.tsx
@@ -1,0 +1,96 @@
+function Bone({ className }: { className?: string }) {
+  return <div className={`animate-pulse rounded bg-muted/40 ${className ?? ''}`} />
+}
+
+function GhostNode({ className }: { className?: string }) {
+  return (
+    <div
+      className={`absolute rounded-lg border border-border/40 bg-card/60 shadow-sm ${className ?? ''}`}
+    >
+      <div className="flex items-center gap-2 border-b border-border/30 px-3 py-2">
+        <Bone className="h-3 w-3 rounded-full" />
+        <Bone className="h-3 w-16" />
+      </div>
+      <div className="space-y-2 px-3 py-2.5">
+        <Bone className="h-2.5 w-24 bg-muted/25" />
+        <Bone className="h-2.5 w-16 bg-muted/20" />
+      </div>
+    </div>
+  )
+}
+
+export function CanvasSkeleton() {
+  return (
+    <div className="fixed inset-0 flex flex-col overflow-hidden bg-background">
+      {/* Toolbar skeleton */}
+      <header className="z-20 flex h-14 shrink-0 items-center justify-between border-b border-border bg-card px-4">
+        <div className="flex items-center gap-2">
+          <Bone className="h-8 w-8 rounded-md" />
+          <div className="h-5 w-px bg-muted/70" />
+          <Bone className="h-4 w-32" />
+          <Bone className="h-4 w-12 bg-muted/25" />
+        </div>
+        <div className="flex items-center gap-1.5">
+          <Bone className="h-8 w-16 rounded-md" />
+          <Bone className="h-8 w-20 rounded-md" />
+          <Bone className="h-8 w-18 rounded-md" />
+          <div className="h-5 w-px bg-muted/70" />
+          <Bone className="h-8 w-14 rounded-md" />
+          <Bone className="h-8 w-20 rounded-md bg-primary/20" />
+        </div>
+      </header>
+
+      {/* Canvas area with dot grid and ghost nodes */}
+      <div className="relative flex-1 overflow-hidden">
+        {/* Dot grid background */}
+        <svg className="absolute inset-0 h-full w-full" xmlns="http://www.w3.org/2000/svg">
+          <defs>
+            <pattern
+              id="skeleton-dots"
+              x="0"
+              y="0"
+              width="20"
+              height="20"
+              patternUnits="userSpaceOnUse"
+            >
+              <circle cx="1" cy="1" r="0.8" className="fill-muted/30" />
+            </pattern>
+          </defs>
+          <rect width="100%" height="100%" fill="url(#skeleton-dots)" />
+        </svg>
+
+        {/* Ghost nodes */}
+        <GhostNode className="left-[20%] top-[25%] w-44" />
+        <GhostNode className="left-[45%] top-[18%] w-48" />
+        <GhostNode className="left-[38%] top-[50%] w-44" />
+
+        {/* Ghost edges (simple lines between nodes) */}
+        <svg className="absolute inset-0 h-full w-full" xmlns="http://www.w3.org/2000/svg">
+          <line
+            x1="29%"
+            y1="32%"
+            x2="45%"
+            y2="25%"
+            className="stroke-border/30"
+            strokeWidth="1.5"
+            strokeDasharray="4 4"
+          />
+          <line
+            x1="52%"
+            y1="28%"
+            x2="48%"
+            y2="50%"
+            className="stroke-border/30"
+            strokeWidth="1.5"
+            strokeDasharray="4 4"
+          />
+        </svg>
+
+        {/* Node palette skeleton */}
+        <div className="absolute left-4 top-4 z-10">
+          <Bone className="h-9 w-9 rounded-lg" />
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/apps/web/src/routes/_authed/workflows/$workflowId.canvas.tsx
+++ b/apps/web/src/routes/_authed/workflows/$workflowId.canvas.tsx
@@ -3,10 +3,11 @@ import { createServerFn } from '@tanstack/react-start'
 import { lazy, Suspense, useState, useEffect } from 'react'
 import { useQuery } from '@tanstack/react-query'
 import { toast } from 'sonner'
-import { Loader2 } from 'lucide-react'
 import { NodePalette } from '../../../components/canvas/node-palette'
 import { TemplatePicker } from '../../../components/canvas/template-picker'
 import { ClientOnly } from '../../../components/canvas/client-only'
+import { CanvasSkeleton } from '../../../components/canvas/canvas-skeleton'
+import { LoadingView } from '../../../components/ui/loading-view'
 import { useWorkflowStore } from '../../../stores/workflow-store'
 import { SimulationPanel } from '../../../components/canvas/simulation-panel'
 import { BindingsPanel } from '../../../components/canvas/bindings-panel'
@@ -101,7 +102,11 @@ function WorkflowEditorPage() {
   })
 
   // Fetch workflow data
-  const { data: fullData, error: workflowError } = useQuery({
+  const {
+    data: fullData,
+    isLoading: isLoadingWorkflow,
+    error: workflowError,
+  } = useQuery({
     queryKey: ['workflow-full', workflowId, versionParam],
     queryFn: () => api.getWorkflowFull(workflowId, versionParam),
     enabled: ready && !isNew,
@@ -156,82 +161,75 @@ function WorkflowEditorPage() {
     addNode(type, { x: 250 + Math.random() * 200, y: 150 + Math.random() * 200 }, nodeRegistry)
   }
 
+  // Show skeleton while waiting for workflow data (skip for new workflows)
+  const showSkeleton = !isNew && !workflowError && (isLoadingWorkflow || !fullData)
+
   return (
-    <ClientOnly
-      fallback={
-        <div className="fixed inset-0 flex items-center justify-center bg-background">
-          <Loader2 className="h-6 w-6 animate-spin text-muted-foreground/60" />
-        </div>
-      }
-    >
-      <Suspense
-        fallback={
-          <div className="fixed inset-0 flex items-center justify-center bg-background">
-            <Loader2 className="h-6 w-6 animate-spin text-muted-foreground/60" />
-          </div>
-        }
-      >
-        <LazyReactFlowProvider>
-          <div className="fixed inset-0 flex flex-col overflow-hidden bg-background">
-            <EditorToolbar
-              workflowId={workflowId}
-              isNew={isNew}
-              workflowName={metadata.name}
-              currentVersion={currentVersion}
-              nodeCount={nodeCount}
-              isDirty={isDirty}
-              hasActiveDeployment={hasActiveDeployment}
-              hasUndeployedChanges={hasUndeployedChanges}
-              deployedVersion={deployedVersion?.version}
-              showSettings={showSettings}
-              onToggleSettings={() => setShowSettings(!showSettings)}
-              showEditor={showEditor}
-              onToggleEditor={() => setShowEditor(!showEditor)}
-              onSave={handleSave}
-              isSaving={isSaving}
-              onDeploy={handleDeploy}
-              onTest={() => runSimulation()}
-              onTestLocally={localDevEnabled ? () => setShowLocalTest((v) => !v) : undefined}
-              onOpenTemplatePicker={() => {
-                if (nodeCount > 0) {
-                  setConfirmAction('switch-template')
-                } else {
-                  setShowTemplatePicker(true)
-                }
-              }}
-              readOnly={isReadOnly}
-              readOnlyVersion={readOnlyVersion}
-            />
-            <div className="relative flex-1 overflow-hidden">
-              <LazyCanvas />
-              {!isReadOnly && (
-                <div className="absolute left-4 top-4 z-10">
-                  <NodePalette onAddNode={handleAddNode} />
-                </div>
-              )}
-              {isNew && showTemplatePicker && (
-                <TemplatePicker onDismiss={() => setShowTemplatePicker(false)} />
-              )}
-              <BindingsPanel />
-              <SimulationPanel />
-              <CanvasSidePanels
-                showEditor={showEditor}
-                showLocalTest={showLocalTest && !isNew}
-                onCloseLocalTest={() => setShowLocalTest(false)}
+    <ClientOnly fallback={<CanvasSkeleton />}>
+      <Suspense fallback={<CanvasSkeleton />}>
+        <LoadingView isLoading={showSkeleton} LoadingPlaceholder={CanvasSkeleton}>
+          <LazyReactFlowProvider>
+            <div className="fixed inset-0 flex flex-col overflow-hidden bg-background">
+              <EditorToolbar
                 workflowId={workflowId}
-                LazyEditorPanel={LazyEditorPanel}
+                isNew={isNew}
+                workflowName={metadata.name}
+                currentVersion={currentVersion}
+                nodeCount={nodeCount}
+                isDirty={isDirty}
+                hasActiveDeployment={hasActiveDeployment}
+                hasUndeployedChanges={hasUndeployedChanges}
+                deployedVersion={deployedVersion?.version}
+                showSettings={showSettings}
+                onToggleSettings={() => setShowSettings(!showSettings)}
+                showEditor={showEditor}
+                onToggleEditor={() => setShowEditor(!showEditor)}
+                onSave={handleSave}
+                isSaving={isSaving}
+                onDeploy={handleDeploy}
+                onTest={() => runSimulation()}
+                onTestLocally={localDevEnabled ? () => setShowLocalTest((v) => !v) : undefined}
+                onOpenTemplatePicker={() => {
+                  if (nodeCount > 0) {
+                    setConfirmAction('switch-template')
+                  } else {
+                    setShowTemplatePicker(true)
+                  }
+                }}
+                readOnly={isReadOnly}
+                readOnlyVersion={readOnlyVersion}
               />
+              <div className="relative flex-1 overflow-hidden">
+                <LazyCanvas />
+                {!isReadOnly && (
+                  <div className="absolute left-4 top-4 z-10">
+                    <NodePalette onAddNode={handleAddNode} />
+                  </div>
+                )}
+                {isNew && showTemplatePicker && (
+                  <TemplatePicker onDismiss={() => setShowTemplatePicker(false)} />
+                )}
+                <BindingsPanel />
+                <SimulationPanel />
+                <CanvasSidePanels
+                  showEditor={showEditor}
+                  showLocalTest={showLocalTest && !isNew}
+                  onCloseLocalTest={() => setShowLocalTest(false)}
+                  workflowId={workflowId}
+                  LazyEditorPanel={LazyEditorPanel}
+                />
+              </div>
             </div>
-          </div>
-          <EditorDialogs
-            confirmAction={confirmAction}
-            setConfirmAction={setConfirmAction}
-            onConfirmSwitchTemplate={() => setShowTemplatePicker(true)}
-            blockerStatus={status}
-            onBlockerProceed={proceed}
-            onBlockerReset={reset}
-          />
-        </LazyReactFlowProvider>
+            <EditorDialogs
+              confirmAction={confirmAction}
+              setConfirmAction={setConfirmAction}
+              onConfirmSwitchTemplate={() => setShowTemplatePicker(true)}
+              blockerStatus={status}
+              onBlockerProceed={proceed}
+              onBlockerReset={reset}
+            />
+          </LazyReactFlowProvider>
+        </LoadingView>
       </Suspense>
     </ClientOnly>
   )


### PR DESCRIPTION
## Summary
- Add `CanvasSkeleton` component that mirrors the real canvas layout (toolbar bar, dot-grid background, ghost nodes with dashed edges, palette placeholder)
- Replace bare `Loader2` spinner in `ClientOnly` and `Suspense` fallbacks with the skeleton
- Wrap canvas content with `LoadingView` so the skeleton shows during `useQuery` data fetch (skipped for new workflows, cleared on error)
- Add `.claude/worktrees` to `.prettierignore` to prevent pre-commit failures from worktree artifacts

## Test plan
- [ ] Navigate to an existing workflow canvas — skeleton should briefly appear while data loads
- [ ] Navigate to `/workflows/new/canvas` — canvas should render immediately (no skeleton)
- [ ] Hard-refresh the canvas page — skeleton shows during SSR hydration + code splitting
- [ ] Simulate slow network in DevTools — skeleton persists until workflow data resolves
- [ ] Verify error case: if workflow fetch fails, toast appears and skeleton clears (doesn't hang)