### PR TITLE
feat: workflow import/export

### DIFF
--- a/apps/web/src/components/canvas/editor-toolbar.tsx
+++ b/apps/web/src/components/canvas/editor-toolbar.tsx
@@ -11,6 +11,7 @@ import {
   Circle,
   LayoutTemplate,
   Terminal,
+  Download,
 } from 'lucide-react'
 import { Button } from '../ui/button'
 import { cn } from '../../lib/utils'
@@ -35,6 +36,7 @@ export interface EditorToolbarProps {
   onTest: () => void
   onTestLocally?: () => void
   onOpenTemplatePicker: () => void
+  onExport?: () => void
   readOnly?: boolean
   readOnlyVersion?: number
 }
@@ -59,6 +61,7 @@ export function EditorToolbar({
   onTest,
   onTestLocally,
   onOpenTemplatePicker,
+  onExport,
   readOnly,
   readOnlyVersion,
 }: EditorToolbarProps) {
@@ -178,6 +181,17 @@ export function EditorToolbar({
               >
                 <LayoutTemplate className="h-3.5 w-3.5" />
                 <span className="text-xs">Templates</span>
+              </Button>
+            )}
+            {onExport && (
+              <Button
+                variant="ghost"
+                size="sm"
+                className="h-8 gap-1.5 px-2.5 text-muted-foreground hover:text-foreground/70"
+                onClick={onExport}
+              >
+                <Download className="h-3.5 w-3.5" />
+                <span className="text-xs">Export</span>
               </Button>
             )}
             <div className="h-5 w-px bg-muted/70" />

--- a/apps/web/src/components/dashboard/import-workflow-dialog.tsx
+++ b/apps/web/src/components/dashboard/import-workflow-dialog.tsx
@@ -1,0 +1,292 @@
+import { useState, useRef } from 'react'
+import { useNavigate } from '@tanstack/react-router'
+import { useMutation, useQueryClient } from '@tanstack/react-query'
+import { Upload, FileText, AlertCircle, Loader2 } from 'lucide-react'
+import * as Dialog from '@radix-ui/react-dialog'
+import { validateIR } from '@awaitstep/ir'
+import type { WorkflowIR } from '@awaitstep/ir'
+import { Button } from '../ui/button'
+import { CodeEditor } from '../ui/code-editor'
+import { api } from '../../lib/api-client'
+import { toast } from 'sonner'
+
+type InputMode = 'paste' | 'file'
+
+function parseAndValidate(
+  raw: string,
+): { ir: WorkflowIR; errors: null } | { ir: null; errors: string[] } {
+  let parsed: unknown
+  try {
+    parsed = JSON.parse(raw)
+  } catch {
+    return { ir: null, errors: ['Invalid JSON — check for syntax errors.'] }
+  }
+
+  const result = validateIR(parsed)
+  if (!result.ok) {
+    return {
+      ir: null,
+      errors: result.errors.map((e) => `${e.path}: ${e.message}`),
+    }
+  }
+
+  return { ir: result.value, errors: null }
+}
+
+export function ImportWorkflowDialog({ onClose }: { onClose: () => void }) {
+  const navigate = useNavigate()
+  const queryClient = useQueryClient()
+
+  const [mode, setMode] = useState<InputMode>('paste')
+  const [jsonText, setJsonText] = useState('')
+  const [fileName, setFileName] = useState<string | null>(null)
+  const [name, setName] = useState('')
+  const [validIR, setValidIR] = useState<WorkflowIR | null>(null)
+  const [errors, setErrors] = useState<string[]>([])
+  const [isDragOver, setIsDragOver] = useState(false)
+  const fileInputRef = useRef<HTMLInputElement>(null)
+
+  function applyValidation(raw: string) {
+    if (!raw.trim()) {
+      setValidIR(null)
+      setErrors([])
+      setName('')
+      return
+    }
+    const result = parseAndValidate(raw)
+    if (result.errors) {
+      setValidIR(null)
+      setErrors(result.errors)
+      setName('')
+    } else {
+      setValidIR(result.ir)
+      setErrors([])
+      setName(result.ir.metadata.name)
+    }
+  }
+
+  function clearState() {
+    setJsonText('')
+    setFileName(null)
+    setValidIR(null)
+    setErrors([])
+    setName('')
+  }
+
+  function switchMode(next: InputMode) {
+    if (next === mode) return
+    clearState()
+    if (fileInputRef.current) fileInputRef.current.value = ''
+    setMode(next)
+  }
+
+  function handlePasteChange(value: string) {
+    setJsonText(value)
+    applyValidation(value)
+  }
+
+  function loadFile(file: File) {
+    if (!file.name.endsWith('.json')) {
+      setErrors(['Please select a .json file.'])
+      return
+    }
+    const reader = new FileReader()
+    reader.onload = (e) => {
+      const text = e.target?.result as string
+      setJsonText(text)
+      setFileName(file.name)
+      applyValidation(text)
+    }
+    reader.readAsText(file)
+  }
+
+  function handleDrop(e: React.DragEvent) {
+    e.preventDefault()
+    setIsDragOver(false)
+    const file = e.dataTransfer.files[0]
+    if (file) {
+      setMode('file')
+      loadFile(file)
+    }
+  }
+
+  function handleDragOver(e: React.DragEvent) {
+    e.preventDefault()
+    setIsDragOver(true)
+  }
+
+  const importMutation = useMutation({
+    mutationFn: async () => {
+      if (!validIR) throw new Error('No valid IR')
+      const workflow = await api.createWorkflow({
+        name: name.trim() || validIR.metadata.name,
+        description: validIR.metadata.description,
+      })
+      await api.createVersion(workflow.id, { ir: validIR })
+      return workflow
+    },
+    onSuccess: (workflow) => {
+      queryClient.invalidateQueries({ queryKey: ['workflows'] })
+      navigate({
+        to: '/workflows/$workflowId/canvas',
+        params: { workflowId: workflow.id },
+      }).finally(() => {
+        toast.success('Workflow imported')
+        onClose()
+      })
+    },
+    onError: (err) => {
+      toast.error(err instanceof Error ? err.message : 'Failed to import workflow')
+    },
+  })
+
+  const hasInput = jsonText.trim().length > 0
+  const canImport = validIR !== null && !importMutation.isPending
+
+  return (
+    <Dialog.Root open onOpenChange={(v) => !v && onClose()}>
+      <Dialog.Portal>
+        <Dialog.Overlay className="fixed inset-0 z-50 bg-black/60" />
+        <Dialog.Content
+          className="fixed left-1/2 top-1/2 z-50 w-[540px] -translate-x-1/2 -translate-y-1/2 rounded-md border border-border bg-card p-6 shadow-lg"
+          onDrop={handleDrop}
+          onDragOver={handleDragOver}
+          onDragLeave={() => setIsDragOver(false)}
+        >
+          <Dialog.Title className="text-base font-semibold text-foreground">
+            Import Workflow
+          </Dialog.Title>
+          <p className="mt-1 text-xs text-muted-foreground">
+            Paste an IR JSON document or upload an exported <code>.ir.json</code> file.
+          </p>
+
+          {/* Mode tabs */}
+          <div className="mt-4 flex gap-1 rounded-md border border-border bg-muted/40 p-0.5">
+            <button
+              onClick={() => switchMode('paste')}
+              className={`flex-1 rounded px-3 py-1.5 text-xs font-medium transition-colors ${
+                mode === 'paste'
+                  ? 'bg-card text-foreground shadow-sm'
+                  : 'text-muted-foreground hover:text-foreground/60'
+              }`}
+            >
+              Paste JSON
+            </button>
+            <button
+              onClick={() => switchMode('file')}
+              className={`flex-1 rounded px-3 py-1.5 text-xs font-medium transition-colors ${
+                mode === 'file'
+                  ? 'bg-card text-foreground shadow-sm'
+                  : 'text-muted-foreground hover:text-foreground/60'
+              }`}
+            >
+              Upload file
+            </button>
+          </div>
+
+          {/* Input area */}
+          <div className="mt-3">
+            {mode === 'paste' ? (
+              <CodeEditor
+                value={jsonText}
+                onChange={handlePasteChange}
+                language="json"
+                height="288px"
+                expandable={false}
+              />
+            ) : (
+              <div
+                onClick={() => fileInputRef.current?.click()}
+                className={`flex h-48 cursor-pointer flex-col items-center justify-center rounded-md border-2 border-dashed transition-colors ${
+                  isDragOver
+                    ? 'border-primary/60 bg-primary/5'
+                    : fileName
+                      ? 'border-border bg-muted/20'
+                      : 'border-border bg-muted/30 hover:border-primary/30 hover:bg-muted/40'
+                }`}
+              >
+                {fileName ? (
+                  <>
+                    <FileText className="h-8 w-8 text-primary/60" />
+                    <span className="mt-2 text-sm font-medium text-foreground">{fileName}</span>
+                    <span className="mt-0.5 text-xs text-muted-foreground">
+                      Click to choose a different file
+                    </span>
+                  </>
+                ) : (
+                  <>
+                    <Upload className="h-8 w-8 text-muted-foreground/40" />
+                    <span className="mt-2 text-sm text-muted-foreground">
+                      Drop a file here or click to browse
+                    </span>
+                    <span className="mt-0.5 text-xs text-muted-foreground/60">
+                      .json files only
+                    </span>
+                  </>
+                )}
+                <input
+                  ref={fileInputRef}
+                  type="file"
+                  accept=".json"
+                  onChange={(e) => {
+                    const file = e.target.files?.[0]
+                    if (file) loadFile(file)
+                  }}
+                  className="hidden"
+                />
+              </div>
+            )}
+          </div>
+
+          {/* Validation errors */}
+          {hasInput && errors.length > 0 && (
+            <div className="mt-3 max-h-28 overflow-y-auto rounded-md border border-destructive/30 bg-destructive/5 p-3">
+              <div className="flex items-start gap-2">
+                <AlertCircle className="mt-0.5 h-3.5 w-3.5 shrink-0 text-destructive" />
+                <div className="space-y-1">
+                  {errors.slice(0, 5).map((err, i) => (
+                    <p key={i} className="text-xs text-destructive">
+                      {err}
+                    </p>
+                  ))}
+                  {errors.length > 5 && (
+                    <p className="text-xs text-destructive/70">
+                      ...and {errors.length - 5} more errors
+                    </p>
+                  )}
+                </div>
+              </div>
+            </div>
+          )}
+
+          {/* Workflow name (shown when IR is valid) */}
+          {validIR && (
+            <div className="mt-3">
+              <label className="text-xs font-medium text-foreground/60">Workflow name</label>
+              <input
+                type="text"
+                value={name}
+                onChange={(e) => setName(e.target.value)}
+                className="mt-1 w-full rounded-md border border-border bg-muted/30 px-3 py-2 text-sm text-foreground outline-none focus:border-primary/40"
+              />
+              <p className="mt-1.5 text-xs text-muted-foreground">
+                {validIR.nodes.length} nodes, {validIR.edges.length} edges
+              </p>
+            </div>
+          )}
+
+          {/* Actions */}
+          <div className="mt-5 flex justify-end gap-2">
+            <Button variant="ghost" size="sm" onClick={onClose}>
+              Cancel
+            </Button>
+            <Button size="sm" disabled={!canImport} onClick={() => importMutation.mutate()}>
+              {importMutation.isPending && <Loader2 className="h-3.5 w-3.5 animate-spin" />}
+              Import
+            </Button>
+          </div>
+        </Dialog.Content>
+      </Dialog.Portal>
+    </Dialog.Root>
+  )
+}

--- a/apps/web/src/components/dashboard/workflow-actions-menu.tsx
+++ b/apps/web/src/components/dashboard/workflow-actions-menu.tsx
@@ -11,14 +11,19 @@ import {
 } from '../ui/dropdown-menu'
 import { ConfirmDialog } from '../ui/confirm-dialog'
 import { api, type WorkflowSummary } from '../../lib/api-client'
+import { downloadJsonFile } from '../../lib/download-file'
+import { toast } from 'sonner'
 
 interface WorkflowActionsMenuProps {
   workflow: WorkflowSummary
-  irJson?: string
   isDeployed?: boolean
 }
 
-export function WorkflowActionsMenu({ workflow, irJson, isDeployed }: WorkflowActionsMenuProps) {
+function irFileName(name: string) {
+  return `${name.replace(/\s+/g, '-').toLowerCase()}.ir.json`
+}
+
+export function WorkflowActionsMenu({ workflow, isDeployed }: WorkflowActionsMenuProps) {
   const navigate = useNavigate()
   const queryClient = useQueryClient()
   const [deleteOpen, setDeleteOpen] = useState(false)
@@ -54,8 +59,9 @@ export function WorkflowActionsMenu({ workflow, irJson, isDeployed }: WorkflowAc
         name: `${workflow.name} (copy)`,
         description: workflow.description,
       })
-      if (irJson) {
-        await api.createVersion(newWf.id, { ir: JSON.parse(irJson) })
+      if (workflow.currentVersionId) {
+        const ver = await api.getVersion(workflow.id, workflow.currentVersionId)
+        await api.createVersion(newWf.id, { ir: JSON.parse(ver.ir) })
       }
       return newWf
     },
@@ -65,16 +71,21 @@ export function WorkflowActionsMenu({ workflow, irJson, isDeployed }: WorkflowAc
     },
   })
 
-  function handleExportIR() {
-    if (!irJson) return
-    const blob = new Blob([irJson], { type: 'application/json' })
-    const url = URL.createObjectURL(blob)
-    const a = document.createElement('a')
-    a.href = url
-    a.download = `${workflow.name.replace(/\s+/g, '-').toLowerCase()}.ir.json`
-    a.click()
-    URL.revokeObjectURL(url)
-  }
+  const exportMutation = useMutation({
+    mutationFn: async () => {
+      if (!workflow.currentVersionId) throw new Error('No version to export')
+      const ver = await api.getVersion(workflow.id, workflow.currentVersionId)
+      return ver.ir
+    },
+    onSuccess: (irJson) => {
+      downloadJsonFile(irFileName(workflow.name), irJson)
+    },
+    onError: (err) => {
+      toast.error(err instanceof Error ? err.message : 'Failed to export workflow')
+    },
+  })
+
+  const hasVersion = !!workflow.currentVersionId
 
   return (
     <>
@@ -108,15 +119,16 @@ export function WorkflowActionsMenu({ workflow, irJson, isDeployed }: WorkflowAc
           <DropdownMenuSeparator />
           <DropdownMenuItem
             onSelect={() => duplicateMutation.mutate()}
-            disabled={duplicateMutation.isPending}
+            disabled={duplicateMutation.isPending || !hasVersion}
           >
             <Copy size={14} /> Duplicate
           </DropdownMenuItem>
-          {irJson && (
-            <DropdownMenuItem onSelect={handleExportIR}>
-              <Download size={14} /> Export IR
-            </DropdownMenuItem>
-          )}
+          <DropdownMenuItem
+            onSelect={() => exportMutation.mutate()}
+            disabled={exportMutation.isPending || !hasVersion}
+          >
+            <Download size={14} /> Export IR
+          </DropdownMenuItem>
           {isDeployed && (
             <>
               <DropdownMenuSeparator />

--- a/apps/web/src/lib/download-file.ts
+++ b/apps/web/src/lib/download-file.ts
@@ -1,0 +1,9 @@
+export function downloadJsonFile(filename: string, content: string) {
+  const blob = new Blob([content], { type: 'application/json' })
+  const url = URL.createObjectURL(blob)
+  const a = document.createElement('a')
+  a.href = url
+  a.download = filename
+  a.click()
+  URL.revokeObjectURL(url)
+}

--- a/apps/web/src/routes/_authed/workflows.index.tsx
+++ b/apps/web/src/routes/_authed/workflows.index.tsx
@@ -1,5 +1,5 @@
 import { createFileRoute, Link } from '@tanstack/react-router'
-import { Plus, Search } from 'lucide-react'
+import { Plus, Search, Upload } from 'lucide-react'
 import { useState, useMemo } from 'react'
 import { Button } from '../../components/ui/button'
 import { GuardedLink } from '../../components/ui/guarded-link'
@@ -8,6 +8,7 @@ import type { WorkflowSummary } from '../../lib/api-client'
 import { useWorkflowsStore } from '../../stores/workflows-store'
 import { WorkflowActionsMenu } from '../../components/dashboard/workflow-actions-menu'
 import { TriggerButton } from '../../components/dashboard/trigger-button'
+import { ImportWorkflowDialog } from '../../components/dashboard/import-workflow-dialog'
 import { timeAgo } from '../../lib/time'
 import { RequireProject } from '../../wrappers/require-project'
 import { NEW_WORKFLOW_NAV } from '../../lib/nav'
@@ -37,6 +38,7 @@ function WorkflowsIndexContent() {
   const loadMore = useWorkflowsStore((s) => s.loadMore)
   const isFetchingMore = useWorkflowsStore((s) => s.isFetchingMore)
   const [search, setSearch] = useState('')
+  const [importOpen, setImportOpen] = useState(false)
 
   const filtered = useMemo(() => {
     if (!search.trim()) return workflows
@@ -52,12 +54,23 @@ function WorkflowsIndexContent() {
         title="Workflows"
         breadcrumbs={[{ label: 'Home', href: '/dashboard' }, { label: 'Workflows' }]}
         actions={
-          <Button size="sm" className="gap-1.5" asChild>
-            <GuardedLink requirement="project" nav={NEW_WORKFLOW_NAV}>
-              <Plus className="h-4 w-4" />
-              New Workflow
-            </GuardedLink>
-          </Button>
+          <div className="flex items-center gap-2">
+            <Button
+              variant="outline"
+              size="sm"
+              className="gap-1.5"
+              onClick={() => setImportOpen(true)}
+            >
+              <Upload className="h-4 w-4" />
+              Import
+            </Button>
+            <Button size="sm" className="gap-1.5" asChild>
+              <GuardedLink requirement="project" nav={NEW_WORKFLOW_NAV}>
+                <Plus className="h-4 w-4" />
+                New Workflow
+              </GuardedLink>
+            </Button>
+          </div>
         }
       />
 
@@ -114,6 +127,8 @@ function WorkflowsIndexContent() {
           </p>
         )}
       </div>
+
+      {importOpen && <ImportWorkflowDialog onClose={() => setImportOpen(false)} />}
     </div>
   )
 }

--- a/apps/web/src/routes/_authed/workflows/$workflowId.canvas.tsx
+++ b/apps/web/src/routes/_authed/workflows/$workflowId.canvas.tsx
@@ -24,6 +24,9 @@ import {
   deriveDeploymentState,
 } from '../../../lib/hydrate-workflow'
 import { useWorkflowPersistence } from '../../../hooks/use-workflow-persistence'
+import { buildIRFromState } from '../../../lib/build-ir'
+import { serializeIR } from '@awaitstep/ir'
+import { downloadJsonFile } from '../../../lib/download-file'
 
 const LazyReactFlowProvider = lazy(() =>
   import('@xyflow/react').then((m) => ({ default: m.ReactFlowProvider })),
@@ -161,6 +164,14 @@ function WorkflowEditorPage() {
     addNode(type, { x: 250 + Math.random() * 200, y: 150 + Math.random() * 200 }, nodeRegistry)
   }
 
+  function handleExport() {
+    const state = useWorkflowStore.getState()
+    const ir = buildIRFromState(state)
+    const json = serializeIR(ir)
+    const filename = `${metadata.name.replace(/\s+/g, '-').toLowerCase()}.ir.json`
+    downloadJsonFile(filename, json)
+  }
+
   // Show skeleton while waiting for workflow data (skip for new workflows)
   const showSkeleton = !isNew && !workflowError && (isLoadingWorkflow || !fullData)
 
@@ -189,6 +200,7 @@ function WorkflowEditorPage() {
                 onDeploy={handleDeploy}
                 onTest={() => runSimulation()}
                 onTestLocally={localDevEnabled ? () => setShowLocalTest((v) => !v) : undefined}
+                onExport={nodeCount > 0 ? handleExport : undefined}
                 onOpenTemplatePicker={() => {
                   if (nodeCount > 0) {
                     setConfirmAction('switch-template')

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -138,6 +138,22 @@ The WorkflowIR is the single source of truth. The canvas serializes to IR,
 codegen reads IR, validation operates on IR, and versioning stores IR as JSON.
 The IR is provider-agnostic — provider packages transform it into runtime-specific code.
 
+### Workflow Import / Export
+
+Workflows can be exported and imported as `.ir.json` files containing the full `WorkflowIR` document (metadata, nodes, edges, entryNodeId).
+
+**Export** is available from:
+
+- **Canvas toolbar** — "Export" button builds IR from the current editor state and downloads it. Available when the canvas has at least one node.
+- **Workflow actions menu** — "Export IR" option on the workflow overview and list pages. Fetches the current version's IR from the API on demand.
+
+**Import** is available from the Workflows list page via the "Import" button. The import dialog supports two input modes:
+
+- **Paste JSON** — Monaco editor with JSON syntax highlighting for pasting IR directly.
+- **Upload file** — File picker or drag-and-drop for `.json` files.
+
+On input, the IR is validated client-side using `validateIR()` from `@awaitstep/ir` (schema + structural checks). If valid, the user can edit the workflow name before importing. Import creates a new workflow via `POST /workflows` and saves the IR as version 1 via `POST /workflows/:id/versions`, then navigates to the canvas editor.
+
 ### Token Encryption
 
 API tokens and secrets are encrypted at rest using AES-256-GCM via the Web Crypto API.


### PR DESCRIPTION
## Summary
- Add workflow import dialog on the workflows list page with Monaco JSON editor for pasting IR and file upload with drag-and-drop
- Make Export IR available from all surfaces: workflow actions menu (list + overview pages) fetches version on demand, canvas toolbar exports current editor state
- Extract shared `downloadJsonFile` helper, remove unused `irJson` prop from `WorkflowActionsMenu`
- Document import/export in architecture.md

## Test plan
- [ ] Open workflows list, click Import, paste valid IR JSON — verify validation passes, name pre-fills, import creates workflow and navigates to canvas
- [ ] Import via file upload (click to browse + drag-and-drop)
- [ ] Paste invalid JSON — verify error messages appear inline
- [ ] Switch between Paste/Upload tabs — verify state resets
- [ ] Export from canvas toolbar — verify .ir.json file downloads with current editor state
- [ ] Export from workflow actions menu on list and overview pages — verify file downloads
- [ ] Duplicate workflow from actions menu — verify it still works (now fetches version on demand)