### PR TITLE
fix: use CF REST API for worker takedown

### DIFF
--- a/apps/web/src/components/dashboard/workflow-actions-menu.tsx
+++ b/apps/web/src/components/dashboard/workflow-actions-menu.tsx
@@ -46,13 +46,18 @@ export function WorkflowActionsMenu({ workflow, isDeployed }: WorkflowActionsMen
     mutationFn: async () => {
       const connsResult = await api.listConnections()
       if (connsResult.data.length === 0) throw new Error('No connection available')
-      return api.takedownDeployment(workflow.id, connsResult.data[0].id)
+      const result = await api.takedownDeployment(workflow.id, connsResult.data[0].id)
+      if (!result.success) throw new Error(result.error ?? 'Failed to take down workflow')
+      return result
     },
-    onSuccess: (result) => {
-      if (!result.success) throw new Error(result.error ?? 'Failed to take down')
+    onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ['workflows'] })
       queryClient.invalidateQueries({ queryKey: ['all-deployments'] })
       setTakedownOpen(false)
+      toast.success('Workflow taken down')
+    },
+    onError: (err) => {
+      toast.error(err instanceof Error ? err.message : 'Failed to take down workflow')
     },
   })
 

--- a/apps/web/src/lib/api-client.ts
+++ b/apps/web/src/lib/api-client.ts
@@ -35,7 +35,15 @@ async function request<T>(path: string, options?: RequestInit): Promise<T> {
 
   if (!res.ok) {
     const text = await res.text().catch(() => res.statusText)
-    throw new Error(`API ${res.status}: ${text}`)
+    // Try to extract a human-readable error from JSON response
+    let message: string
+    try {
+      const json = JSON.parse(text) as { error?: string; message?: string }
+      message = json.error ?? json.message ?? text
+    } catch {
+      message = text
+    }
+    throw new Error(message)
   }
 
   return res.json()

--- a/packages/provider-cloudflare/src/adapter.ts
+++ b/packages/provider-cloudflare/src/adapter.ts
@@ -386,9 +386,19 @@ export class CloudflareWorkflowsAdapter implements WorkflowProvider, LocalDevPro
     deploymentId: string,
     config: ProviderConfig,
   ): Promise<{ success: boolean; error?: string }> {
-    if (!this.deployer) return { success: false, error: 'No deployer configured' }
     const { accountId, apiToken } = extractCredentials(config)
-    return this.deployer.deleteWorker(deploymentId, { accountId, apiToken })
+    try {
+      const api = new CloudflareAPI({ accountId, apiToken })
+      await api.deleteWorker(deploymentId)
+      return { success: true }
+    } catch (err) {
+      const message = (err as Error).message
+      // Worker already gone — treat as successful takedown
+      if (message.includes('does not exist')) {
+        return { success: true }
+      }
+      return { success: false, error: message }
+    }
   }
 
   async startLocalDev(

--- a/packages/provider-cloudflare/src/api.ts
+++ b/packages/provider-cloudflare/src/api.ts
@@ -174,6 +174,11 @@ export class CloudflareAPI {
     return results
   }
 
+  async deleteWorker(scriptName: string): Promise<void> {
+    validatePathSegment(scriptName, 'scriptName')
+    await this.request('DELETE', `/accounts/${this.config.accountId}/workers/scripts/${scriptName}`)
+  }
+
   private async request(
     method: string,
     path: string,


### PR DESCRIPTION
## Summary

- Replace sandbox container approach for worker deletion with a direct CF REST API call (`DELETE /workers/scripts/{name}`)
- Treat "Worker does not exist" as successful takedown so local deployment records are always cleaned up
- Parse JSON error responses in the web API client instead of showing raw `API 500: {"success":false,...}`
- Fix takedown mutation throwing in `onSuccess` (doesn't trigger `onError`) — moved to `mutationFn`

## Test plan
- [ ] Take down a deployed workflow — should succeed and show "Workflow taken down" toast
- [ ] Take down a workflow whose worker was already deleted on CF — should still succeed
- [ ] Take down with invalid credentials — should show a readable error toast, not raw JSON