### PR TITLE
fix(provider-cloudflare): upload secrets via wrangler secret bulk

### DIFF
--- a/packages/provider-cloudflare/src/__tests__/deploy.test.ts
+++ b/packages/provider-cloudflare/src/__tests__/deploy.test.ts
@@ -94,4 +94,59 @@ describe('deployWithWrangler', () => {
     const content = configWrite?.[1] as string
     expect(content).toContain(WRANGLER_BASE_CONFIG.compatibility_date)
   })
+
+  it('uploads secrets via `wrangler secret bulk` with a JSON file', async () => {
+    const { writeFile, rm } = await import('node:fs/promises')
+    const writeFileMock = vi.mocked(writeFile)
+    const rmMock = vi.mocked(rm)
+    writeFileMock.mockClear()
+    rmMock.mockClear()
+
+    await deployWithWrangler(artifact, {
+      ...options,
+      secrets: { AWS_ACCESS_KEY_ID: 'AKIA', AWS_SECRET_ACCESS_KEY: 's3cr3t' },
+    })
+
+    const bulkCall = mockExecFile.mock.calls.find(
+      (call) =>
+        Array.isArray(call[1]) &&
+        (call[1] as string[]).includes('secret') &&
+        (call[1] as string[]).includes('bulk'),
+    )
+    expect(bulkCall).toBeDefined()
+    const args = bulkCall![1] as string[]
+    expect(args).toEqual([
+      'wrangler',
+      'secret',
+      'bulk',
+      '.secrets.bulk.json',
+      '--name',
+      'awaitstep-my-workflow',
+    ])
+
+    const bulkWrite = writeFileMock.mock.calls.find((call) =>
+      (call[0] as string).endsWith('.secrets.bulk.json'),
+    )
+    expect(bulkWrite).toBeDefined()
+    expect(JSON.parse(bulkWrite![1] as string)).toEqual({
+      AWS_ACCESS_KEY_ID: 'AKIA',
+      AWS_SECRET_ACCESS_KEY: 's3cr3t',
+    })
+
+    const secretsRm = rmMock.mock.calls.find((call) =>
+      (call[0] as string).endsWith('.secrets.bulk.json'),
+    )
+    expect(secretsRm).toBeDefined()
+  })
+
+  it('skips the bulk call when no secrets are provided', async () => {
+    await deployWithWrangler(artifact, options)
+    const bulkCall = mockExecFile.mock.calls.find(
+      (call) =>
+        Array.isArray(call[1]) &&
+        (call[1] as string[]).includes('secret') &&
+        (call[1] as string[]).includes('bulk'),
+    )
+    expect(bulkCall).toBeUndefined()
+  })
 })

--- a/packages/provider-cloudflare/src/__tests__/deployer-helpers.test.ts
+++ b/packages/provider-cloudflare/src/__tests__/deployer-helpers.test.ts
@@ -1,0 +1,91 @@
+import { describe, it, expect } from 'vitest'
+import {
+  buildSecretsBulkJson,
+  redactSensitive,
+  safeFilename,
+  validateSecretKey,
+  SECRETS_BULK_FILENAME,
+} from '../deploy/deployer.js'
+
+describe('validateSecretKey', () => {
+  it('accepts env-var style identifiers', () => {
+    expect(validateSecretKey('AWS_ACCESS_KEY_ID')).toBe(true)
+    expect(validateSecretKey('_internal')).toBe(true)
+    expect(validateSecretKey('a1')).toBe(true)
+  })
+
+  it('rejects keys starting with a digit or containing special chars', () => {
+    expect(validateSecretKey('1bad')).toBe(false)
+    expect(validateSecretKey('with space')).toBe(false)
+    expect(validateSecretKey('a;rm -rf /')).toBe(false)
+    expect(validateSecretKey('')).toBe(false)
+  })
+})
+
+describe('redactSensitive', () => {
+  it('replaces 30+ char alphanumeric runs', () => {
+    const long = 'a'.repeat(40)
+    expect(redactSensitive(`token=${long} done`)).toBe('token=[REDACTED] done')
+  })
+
+  it('leaves short strings untouched', () => {
+    expect(redactSensitive('abc xyz')).toBe('abc xyz')
+  })
+})
+
+describe('safeFilename', () => {
+  it('returns the basename, stripping directory components', () => {
+    expect(safeFilename('worker.js')).toBe('worker.js')
+    expect(safeFilename('/a/b/worker.js')).toBe('worker.js')
+    expect(safeFilename('../etc/passwd')).toBe('passwd')
+  })
+
+  it('rejects empty or pure-`..` names', () => {
+    expect(() => safeFilename('')).toThrow('Invalid artifact filename')
+    expect(() => safeFilename('..')).toThrow('Invalid artifact filename')
+    expect(() => safeFilename('foo..bar')).toThrow('Invalid artifact filename')
+  })
+})
+
+describe('buildSecretsBulkJson', () => {
+  it('returns null json when no secrets are provided', () => {
+    expect(buildSecretsBulkJson(undefined)).toEqual({ json: null, valid: [], skipped: [] })
+    expect(buildSecretsBulkJson({})).toEqual({ json: null, valid: [], skipped: [] })
+  })
+
+  it('serializes valid secrets as JSON', () => {
+    const result = buildSecretsBulkJson({ AWS_ACCESS_KEY_ID: 'AKIA', AWS_SECRET: 's3cr3t' })
+    expect(result.valid).toEqual(['AWS_ACCESS_KEY_ID', 'AWS_SECRET'])
+    expect(result.skipped).toEqual([])
+    expect(JSON.parse(result.json!)).toEqual({
+      AWS_ACCESS_KEY_ID: 'AKIA',
+      AWS_SECRET: 's3cr3t',
+    })
+  })
+
+  it('skips invalid keys but keeps valid ones', () => {
+    const result = buildSecretsBulkJson({ GOOD: 'v', '1bad': 'x', 'with space': 'y' })
+    expect(result.valid).toEqual(['GOOD'])
+    expect(result.skipped).toEqual(['1bad', 'with space'])
+    expect(JSON.parse(result.json!)).toEqual({ GOOD: 'v' })
+  })
+
+  it('returns null json when every key is invalid', () => {
+    const result = buildSecretsBulkJson({ '1bad': 'x' })
+    expect(result.json).toBeNull()
+    expect(result.valid).toEqual([])
+    expect(result.skipped).toEqual(['1bad'])
+  })
+
+  it('preserves values containing special characters via JSON encoding', () => {
+    const result = buildSecretsBulkJson({ SECRET: 'line1\nline2\t"quoted"' })
+    expect(JSON.parse(result.json!)).toEqual({ SECRET: 'line1\nline2\t"quoted"' })
+  })
+})
+
+describe('SECRETS_BULK_FILENAME', () => {
+  it('is a dot-prefixed filename so it sorts away from worker code', () => {
+    expect(SECRETS_BULK_FILENAME.startsWith('.')).toBe(true)
+    expect(SECRETS_BULK_FILENAME.endsWith('.json')).toBe(true)
+  })
+})

--- a/packages/provider-cloudflare/src/__tests__/sandbox-deployer.test.ts
+++ b/packages/provider-cloudflare/src/__tests__/sandbox-deployer.test.ts
@@ -1,0 +1,188 @@
+import { describe, it, expect, vi } from 'vitest'
+import { SandboxWranglerDeployer } from '../deploy/sandbox-deployer.js'
+import type { GeneratedArtifact } from '@awaitstep/codegen'
+
+interface ExecCall {
+  command: string
+  cwd?: string
+  env?: Record<string, string | undefined>
+  stdin?: string
+}
+
+interface FakeSandbox {
+  files: Map<string, string>
+  execCalls: ExecCall[]
+  destroyed: boolean
+  writeFile(path: string, content: string): Promise<void>
+  exec(
+    command: string,
+    options?: {
+      cwd?: string
+      env?: Record<string, string | undefined>
+      stdin?: string
+      onOutput?: (s: string, d: string) => void
+      stream?: boolean
+    },
+  ): Promise<{ success: boolean; stdout: string; stderr: string; exitCode: number }>
+  destroy(): Promise<void>
+}
+
+function makeFakeSandbox(
+  execHandler: (cmd: string) => { success: boolean; stdout?: string; stderr?: string },
+): FakeSandbox {
+  const fake: FakeSandbox = {
+    files: new Map(),
+    execCalls: [],
+    destroyed: false,
+    async writeFile(path, content) {
+      fake.files.set(path, content)
+    },
+    async exec(command, options) {
+      fake.execCalls.push({
+        command,
+        cwd: options?.cwd,
+        env: options?.env,
+        stdin: options?.stdin,
+      })
+      const r = execHandler(command)
+      return { success: r.success, stdout: r.stdout ?? '', stderr: r.stderr ?? '', exitCode: 0 }
+    },
+    async destroy() {
+      fake.destroyed = true
+    },
+  }
+  return fake
+}
+
+const artifact: GeneratedArtifact = {
+  filename: 'worker.js',
+  source: 'export class Test {}',
+  compiled: 'export class Test {}',
+}
+
+const baseOptions = {
+  workflowId: 'my-workflow',
+  workflowName: 'my-workflow',
+  accountId: 'abc123',
+  apiToken: 'token123',
+}
+
+describe('SandboxWranglerDeployer', () => {
+  it('uploads secrets via `wrangler secret bulk` with a JSON file', async () => {
+    let lastSandbox: FakeSandbox | undefined
+    const deployer = new SandboxWranglerDeployer((id: string) => {
+      expect(id).toBeDefined()
+      lastSandbox = makeFakeSandbox((cmd) => {
+        if (cmd.includes('wrangler deploy')) {
+          return { success: true, stdout: 'https://my-worker.example.workers.dev' }
+        }
+        return { success: true }
+      })
+      return lastSandbox
+    })
+
+    const result = await deployer.deploy(artifact, {
+      ...baseOptions,
+      secrets: { AWS_ACCESS_KEY_ID: 'AKIA', AWS_SECRET_ACCESS_KEY: 's3cr3t' },
+    })
+
+    expect(result.success).toBe(true)
+    expect(lastSandbox).toBeDefined()
+    expect(lastSandbox!.destroyed).toBe(true)
+
+    expect(lastSandbox!.files.get('/workspace/.secrets.bulk.json')).toBeDefined()
+    expect(JSON.parse(lastSandbox!.files.get('/workspace/.secrets.bulk.json')!)).toEqual({
+      AWS_ACCESS_KEY_ID: 'AKIA',
+      AWS_SECRET_ACCESS_KEY: 's3cr3t',
+    })
+
+    const bulkCall = lastSandbox!.execCalls.find((c) => c.command.includes('secret bulk'))
+    expect(bulkCall).toBeDefined()
+    expect(bulkCall!.command).toBe(
+      'npx wrangler secret bulk .secrets.bulk.json --name awaitstep-my-workflow',
+    )
+    expect(bulkCall!.cwd).toBe('/workspace')
+    expect(bulkCall!.env?.CLOUDFLARE_API_TOKEN).toBe('token123')
+
+    const cleanupCall = lastSandbox!.execCalls.find((c) => c.command.startsWith('rm -f'))
+    expect(cleanupCall).toBeDefined()
+  })
+
+  it('does not call `wrangler secret put` (legacy stdin-based path)', async () => {
+    let lastSandbox: FakeSandbox | undefined
+    const deployer = new SandboxWranglerDeployer((_id: string) => {
+      lastSandbox = makeFakeSandbox(() => ({ success: true, stdout: 'deployed' }))
+      return lastSandbox
+    })
+
+    await deployer.deploy(artifact, {
+      ...baseOptions,
+      secrets: { FOO: 'bar' },
+    })
+
+    const putCall = lastSandbox!.execCalls.find((c) => c.command.includes('secret put'))
+    expect(putCall).toBeUndefined()
+  })
+
+  it('returns failure when the bulk upload fails and reports a redacted error', async () => {
+    const longToken = 'A'.repeat(40)
+    const deployer = new SandboxWranglerDeployer(() =>
+      makeFakeSandbox((cmd) => {
+        if (cmd.includes('wrangler deploy')) return { success: true, stdout: 'deployed' }
+        if (cmd.includes('secret bulk')) {
+          return { success: false, stderr: `auth failed token=${longToken}` }
+        }
+        return { success: true }
+      }),
+    )
+
+    const result = await deployer.deploy(artifact, {
+      ...baseOptions,
+      secrets: { FOO: 'bar' },
+    })
+
+    expect(result.success).toBe(false)
+    expect(result.error).toContain('[REDACTED]')
+    expect(result.error).not.toContain(longToken)
+  })
+
+  it('skips the bulk step when no secrets are provided', async () => {
+    let lastSandbox: FakeSandbox | undefined
+    const deployer = new SandboxWranglerDeployer(() => {
+      lastSandbox = makeFakeSandbox(() => ({ success: true, stdout: 'deployed' }))
+      return lastSandbox
+    })
+
+    await deployer.deploy(artifact, baseOptions)
+
+    expect(lastSandbox!.files.has('/workspace/.secrets.bulk.json')).toBe(false)
+    const bulkCall = lastSandbox!.execCalls.find((c) => c.command.includes('secret bulk'))
+    expect(bulkCall).toBeUndefined()
+  })
+
+  it('skips invalid secret keys but still uploads valid ones', async () => {
+    let lastSandbox: FakeSandbox | undefined
+    const progress = vi.fn()
+    const deployer = new SandboxWranglerDeployer(() => {
+      lastSandbox = makeFakeSandbox(() => ({ success: true, stdout: 'deployed' }))
+      return lastSandbox
+    })
+
+    await deployer.deploy(
+      artifact,
+      {
+        ...baseOptions,
+        secrets: { GOOD: 'v', '1bad': 'x' },
+      },
+      progress,
+    )
+
+    expect(JSON.parse(lastSandbox!.files.get('/workspace/.secrets.bulk.json')!)).toEqual({
+      GOOD: 'v',
+    })
+    expect(progress).toHaveBeenCalledWith(
+      'UPLOADING_SECRETS',
+      expect.stringContaining('Skipping invalid secret key "1bad"'),
+    )
+  })
+})

--- a/packages/provider-cloudflare/src/deploy.ts
+++ b/packages/provider-cloudflare/src/deploy.ts
@@ -1,11 +1,12 @@
 import { writeFile, mkdir, rm } from 'node:fs/promises'
 import { join } from 'node:path'
 import { tmpdir } from 'node:os'
-import { execFile, spawn } from 'node:child_process'
+import { execFile } from 'node:child_process'
 import { promisify } from 'node:util'
 import type { GeneratedArtifact } from '@awaitstep/codegen'
 import type { BindingRequirement } from './codegen/bindings.js'
 import type { SubWorkflowBinding } from './codegen/generators/sub-workflow.js'
+import { buildSecretsBulkJson, SECRETS_BULK_FILENAME } from './deploy/deployer.js'
 import { generateWranglerConfig } from './wrangler-config.js'
 import { workerName, workflowClassName, sanitizedWorkflowName } from './naming.js'
 
@@ -108,10 +109,19 @@ export async function deployWithWrangler(
       timeout: 120_000,
     })
 
-    // Upload secrets via wrangler secret put (after deploy so the worker exists)
-    if (options.secrets) {
-      for (const [key, value] of Object.entries(options.secrets)) {
-        await putSecret(key, value, name, wranglerEnv)
+    // Upload secrets via `wrangler secret bulk` (after deploy so the worker exists)
+    const bulk = buildSecretsBulkJson(options.secrets)
+    if (bulk.json) {
+      const secretsPath = join(deployDir, SECRETS_BULK_FILENAME)
+      await writeFile(secretsPath, bulk.json, 'utf-8')
+      try {
+        await execFileAsync(
+          'npx',
+          ['wrangler', 'secret', 'bulk', SECRETS_BULK_FILENAME, '--name', name],
+          { cwd: deployDir, env: wranglerEnv, timeout: 60_000 },
+        )
+      } finally {
+        await rm(secretsPath, { force: true }).catch(() => {})
       }
     }
 
@@ -153,26 +163,4 @@ export async function deleteWorker(
     const error = err as Error
     return { success: false, error: error.message }
   }
-}
-
-function putSecret(
-  key: string,
-  value: string,
-  workerName: string,
-  env: Record<string, string | undefined>,
-): Promise<void> {
-  return new Promise((resolve, reject) => {
-    const child = spawn('npx', ['wrangler', 'secret', 'put', key, '--name', workerName], {
-      env,
-      stdio: ['pipe', 'pipe', 'pipe'],
-      timeout: 30_000,
-    })
-    child.stdin.write(value)
-    child.stdin.end()
-    child.on('close', (code) => {
-      if (code === 0) resolve()
-      else reject(new Error(`wrangler secret put ${key} exited with code ${code}`))
-    })
-    child.on('error', reject)
-  })
 }

--- a/packages/provider-cloudflare/src/deploy/deployer.ts
+++ b/packages/provider-cloudflare/src/deploy/deployer.ts
@@ -24,6 +24,34 @@ export function safeFilename(filename: string): string {
   return base
 }
 
+/** Filename used for `wrangler secret bulk` payload inside the deploy workspace. */
+export const SECRETS_BULK_FILENAME = '.secrets.bulk.json'
+
+/**
+ * Filter and serialize secrets for `wrangler secret bulk`. Skips keys that
+ * fail `validateSecretKey` so the bulk command never receives invalid names.
+ */
+export function buildSecretsBulkJson(secrets: Record<string, string> | undefined): {
+  json: string | null
+  valid: string[]
+  skipped: string[]
+} {
+  if (!secrets) return { json: null, valid: [], skipped: [] }
+  const valid: string[] = []
+  const skipped: string[] = []
+  const filtered: Record<string, string> = {}
+  for (const [key, value] of Object.entries(secrets)) {
+    if (validateSecretKey(key)) {
+      filtered[key] = value
+      valid.push(key)
+    } else {
+      skipped.push(key)
+    }
+  }
+  if (valid.length === 0) return { json: null, valid, skipped }
+  return { json: JSON.stringify(filtered), valid, skipped }
+}
+
 export interface DeployOptions {
   workflowId: string
   workflowName: string

--- a/packages/provider-cloudflare/src/deploy/node-deployer.ts
+++ b/packages/provider-cloudflare/src/deploy/node-deployer.ts
@@ -1,11 +1,16 @@
 import { writeFile, mkdir, rm } from 'node:fs/promises'
 import { join } from 'node:path'
 import { tmpdir } from 'node:os'
-import { execFile, spawn } from 'node:child_process'
+import { execFile } from 'node:child_process'
 import { promisify } from 'node:util'
 import type { GeneratedArtifact } from '@awaitstep/codegen'
 import type { WranglerDeployer, DeployOptions, WranglerDeployResult } from './deployer.js'
-import { validateSecretKey, redactSensitive, safeFilename } from './deployer.js'
+import {
+  buildSecretsBulkJson,
+  redactSensitive,
+  safeFilename,
+  SECRETS_BULK_FILENAME,
+} from './deployer.js'
 import { generateWranglerConfig } from '../wrangler-config.js'
 import { workerName, workflowClassName, sanitizedWorkflowName } from '../naming.js'
 
@@ -89,17 +94,26 @@ export class NodeWranglerDeployer implements WranglerDeployer {
         timeout: 120_000,
       })
 
-      // 5. Upload secrets
-      if (options.secrets && Object.keys(options.secrets).length > 0) {
-        const secretKeys = Object.keys(options.secrets)
-        for (let i = 0; i < secretKeys.length; i++) {
-          const key = secretKeys[i]
-          if (!validateSecretKey(key)) {
-            onProgress?.('UPLOADING_SECRETS', `Skipping invalid secret key "${key}"`)
-            continue
-          }
-          onProgress?.('UPLOADING_SECRETS', `Setting secret ${i + 1} of ${secretKeys.length}...`)
-          await putSecret(key, options.secrets[key], name, wranglerEnv)
+      // 5. Upload secrets via bulk
+      const bulk = buildSecretsBulkJson(options.secrets)
+      for (const skippedKey of bulk.skipped) {
+        onProgress?.('UPLOADING_SECRETS', `Skipping invalid secret key "${skippedKey}"`)
+      }
+      if (bulk.json) {
+        onProgress?.(
+          'UPLOADING_SECRETS',
+          `Uploading ${bulk.valid.length} ${bulk.valid.length === 1 ? 'secret' : 'secrets'}...`,
+        )
+        const secretsPath = join(deployDir, SECRETS_BULK_FILENAME)
+        await writeFile(secretsPath, bulk.json, 'utf-8')
+        try {
+          await execFileAsync(
+            'npx',
+            ['wrangler', 'secret', 'bulk', SECRETS_BULK_FILENAME, '--name', name],
+            { cwd: deployDir, env: wranglerEnv, timeout: 60_000 },
+          )
+        } finally {
+          await rm(secretsPath, { force: true }).catch(() => {})
         }
       }
 
@@ -138,26 +152,4 @@ export class NodeWranglerDeployer implements WranglerDeployer {
       return { success: false, error: redactSensitive((err as Error).message) }
     }
   }
-}
-
-function putSecret(
-  key: string,
-  value: string,
-  name: string,
-  env: Record<string, string | undefined>,
-): Promise<void> {
-  return new Promise((resolve, reject) => {
-    const child = spawn('npx', ['wrangler', 'secret', 'put', key, '--name', name], {
-      env,
-      stdio: ['pipe', 'pipe', 'pipe'],
-      timeout: 30_000,
-    })
-    child.stdin.write(value)
-    child.stdin.end()
-    child.on('close', (code) => {
-      if (code === 0) resolve()
-      else reject(new Error(`wrangler secret put ${key} exited with code ${code}`))
-    })
-    child.on('error', reject)
-  })
 }

--- a/packages/provider-cloudflare/src/deploy/sandbox-deployer.ts
+++ b/packages/provider-cloudflare/src/deploy/sandbox-deployer.ts
@@ -1,6 +1,11 @@
 import type { GeneratedArtifact } from '@awaitstep/codegen'
 import type { WranglerDeployer, DeployOptions, WranglerDeployResult } from './deployer.js'
-import { validateSecretKey, redactSensitive, safeFilename } from './deployer.js'
+import {
+  buildSecretsBulkJson,
+  redactSensitive,
+  safeFilename,
+  SECRETS_BULK_FILENAME,
+} from './deployer.js'
 import { generateWranglerConfig } from '../wrangler-config.js'
 import { workerName, sanitizedWorkflowName, workflowClassName } from '../naming.js'
 
@@ -118,28 +123,45 @@ export class SandboxWranglerDeployer implements WranglerDeployer {
         return { success: false, workerName: name, error: redactSensitive(deployResult.stderr) }
       }
 
-      // 5. Upload secrets
-      if (options.secrets && Object.keys(options.secrets).length > 0) {
-        const secretKeys = Object.keys(options.secrets)
-        for (let i = 0; i < secretKeys.length; i++) {
-          const key = secretKeys[i]
-          if (!validateSecretKey(key)) {
-            onProgress?.('UPLOADING_SECRETS', `Skipping invalid secret key "${key}"`)
-            continue
-          }
-          onProgress?.('UPLOADING_SECRETS', `Setting secret ${i + 1} of ${secretKeys.length}...`)
-          const secretResult = await sandbox.exec(`npx wrangler secret put ${key} --name ${name}`, {
-            cwd: '/workspace',
-            stdin: options.secrets[key],
-            env: {
-              CLOUDFLARE_ACCOUNT_ID: options.accountId,
-              CLOUDFLARE_API_TOKEN: options.apiToken,
+      // 5. Upload secrets via bulk
+      // The Sandbox SDK's exec() does not support stdin, so we write a JSON
+      // file and let `wrangler secret bulk <file>` read it. The file is
+      // deleted as soon as the upload finishes; the container is destroyed
+      // in the `finally` block regardless.
+      const bulk = buildSecretsBulkJson(options.secrets)
+      for (const skippedKey of bulk.skipped) {
+        onProgress?.('UPLOADING_SECRETS', `Skipping invalid secret key "${skippedKey}"`)
+      }
+      if (bulk.json) {
+        onProgress?.(
+          'UPLOADING_SECRETS',
+          `Uploading ${bulk.valid.length} ${bulk.valid.length === 1 ? 'secret' : 'secrets'}...`,
+        )
+        const secretsPath = `/workspace/${SECRETS_BULK_FILENAME}`
+        await sandbox.writeFile(secretsPath, bulk.json)
+        try {
+          const bulkResult = await sandbox.exec(
+            `npx wrangler secret bulk ${SECRETS_BULK_FILENAME} --name ${name}`,
+            {
+              cwd: '/workspace',
+              env: {
+                CLOUDFLARE_ACCOUNT_ID: options.accountId,
+                CLOUDFLARE_API_TOKEN: options.apiToken,
+              },
+              timeout: 60_000,
             },
-            timeout: 30_000,
-          })
-          if (!secretResult.success) {
-            onProgress?.('UPLOADING_SECRETS', `Warning: failed to set secret "${key}"`)
+          )
+          if (!bulkResult.success) {
+            return {
+              success: false,
+              workerName: name,
+              error: redactSensitive(bulkResult.stderr),
+            }
           }
+        } finally {
+          await sandbox
+            .exec(`rm -f ${SECRETS_BULK_FILENAME}`, { cwd: '/workspace' })
+            .catch(() => {})
         }
       }
 


### PR DESCRIPTION
## Summary

- **Bug**: Sandbox deployments deployed workers with empty secret values (e.g. `AWS_ACCESS_KEY_ID=\"\"`), causing runtime errors like *\"AccessKeyId is mandatory for this action\"*. Worked on Node deploys, broke on Cloudflare sandbox.
- **Root cause**: The `@cloudflare/sandbox` SDK's `ExecOptions` has no `stdin` field — passing `stdin: value` to `sandbox.exec(\"npx wrangler secret put ...\")` was silently dropped. Wrangler read EOF and uploaded an empty string for every secret.
- **Fix**: Switch all three deploy paths (sandbox, node, legacy `deployWithWrangler`) to `wrangler secret bulk <file>`, which reads a JSON map from a file — sidestepping the missing-stdin limitation. The bulk file is removed inline after upload (defense in depth on top of existing tmpdir / `sandbox.destroy` cleanup). A sandbox bulk failure now surfaces as `success: false` with a redacted error instead of silently warning — preventing the same masking that hid the original bug.

## Test plan

- [x] `pnpm test` — 270 tests pass in `provider-cloudflare` (19 new), 52 pass in `api`
- [x] `pnpm build` — green
- [x] `pnpm lint` — green
- [x] `pnpm type-check` — green
- [x] Helper unit tests cover `buildSecretsBulkJson` (empty / all-valid / mixed-validity / all-invalid / special-char values)
- [x] Sandbox-deployer integration test with in-memory fake sandbox verifies:
  - JSON file written to `/workspace/.secrets.bulk.json` with correct contents
  - `wrangler secret bulk .secrets.bulk.json --name <worker>` invoked with right cwd/env
  - **Regression guard**: `wrangler secret put` is never called
  - Bulk failure returns `success: false` with redacted stderr
  - No-secrets path skips the bulk step entirely
  - Invalid keys reported via `onProgress` and excluded from the bulk file
- [ ] Manual verification on a real CF sandbox deploy with a workflow that uses AWS-SDK secrets