### PR TITLE
feat: add fromAlias to direct-mail node (v1.0.1) + version-node skill

### DIFF
--- a/.claude/skills/version-node/SKILL.md
+++ b/.claude/skills/version-node/SKILL.md
@@ -1,0 +1,96 @@
+---
+name: version-node
+description: Add a new version of an existing AwaitStep registry node using the overrides method (no file duplication)
+disable-model-invocation: true
+argument-hint: '[node_id] [new_version]'
+---
+
+You are bumping an existing registry node to a new version. Use the **overrides method** — the node config lives in `base.json` at the node root, and each version contributes a small `overrides.json` with only what changes. **Do not duplicate the full schema.**
+
+The canonical reference is `registry/nodes/google-gemini/` — match its file structure 1:1.
+
+---
+
+## Step 1: Validate inputs
+
+The node ID is `$1` and the new version is `$2`.
+
+If either is missing, ask the user.
+
+Validate:
+
+1. `registry/nodes/<node_id>/` must exist.
+2. `<new_version>` must be valid semver and greater than every existing version directory under that node.
+3. `<new_version>/` must NOT already exist.
+
+If the node currently has only `<version>/node.json` and no `base.json` at the node root, the node is on the **legacy single-version layout**. Migrate it first (Step 2). Otherwise skip to Step 3.
+
+## Step 2: Migrate to overrides layout (only if `base.json` is missing)
+
+Read `registry/nodes/<node_id>/<existing_version>/node.json`. Split it:
+
+- **`registry/nodes/<node_id>/base.json`** — every field EXCEPT `version` and `description`.
+- **`registry/nodes/<node_id>/<existing_version>/overrides.json`** — `{ "version": "...", "description": "..." }`.
+
+Leave the existing `<existing_version>/node.json` and `<existing_version>/template.ts` untouched. CI rebuilds `node.json` from base+overrides on the next push to `main`.
+
+## Step 3: Add the new version
+
+Create exactly these files (no others):
+
+### `registry/nodes/<node_id>/<new_version>/overrides.json`
+
+```json
+{
+  "version": "<new_version>",
+  "description": "<updated one-line description>",
+  "configSchema": {
+    "<newOrChangedField>": {
+      ...
+    }
+  }
+}
+```
+
+Rules for `overrides.json`:
+
+- Always include `version` and `description`.
+- Include only the fields that **change** or are **added**. Do NOT re-list unchanged config fields — `deepMerge` (see `registry/scripts/merge.ts`) layers overrides on top of `base.json` recursively.
+- For nested objects (e.g. `configSchema.<field>`), include only the keys that differ; the rest are inherited from base.
+- To override an array (e.g. `tags`, `configSchema.action.options`), supply the full replacement array — arrays are not merged element-wise.
+
+### `registry/nodes/<node_id>/<new_version>/template.ts`
+
+Copy from the previous version and apply the behavior change. Templates are per-version — there is no template inheritance.
+
+## Step 4: Do NOT generate node.json or index.json locally
+
+The CI workflow `.github/workflows/registry-index.yml` runs `registry/scripts/build-index.ts` on push to `main`. It:
+
+1. Merges `base.json` + each version's `overrides.json` and writes the resulting `<version>/node.json`.
+2. Computes checksums and rewrites `registry/index.json`.
+3. Opens an auto-merge PR with the regenerated files.
+
+If you generate these locally, checksums will diverge from CI's output and cache-invalidation issues follow. Just commit `base.json`, `overrides.json`, and `template.ts`.
+
+## Step 5: Validate locally without building
+
+- Confirm the JSON files parse: `node -e "require('./registry/nodes/<id>/base.json'); require('./registry/nodes/<id>/<new_version>/overrides.json')"`.
+- Diff your file tree against `registry/nodes/google-gemini/` — same shape, minus the CI-generated `<new_version>/node.json`.
+
+Do NOT run `npx tsx registry/scripts/build-index.ts`.
+
+## Step 6: Branch, commit, PR
+
+- Branch from `origin/dev`: `feat/<node_id>-<short-summary>` (e.g. `feat/direct-mail-from-alias`).
+- Commit prefix: `feat:` for new user-facing config fields, `fix:` for behavior corrections in the new version, `chore:` for pure metadata bumps.
+- Stage only the new/changed files (`base.json`, `<version>/overrides.json`, `<version>/template.ts`, and migrated overrides for the legacy version if Step 2 ran).
+- Do NOT stage `<version>/node.json` or `registry/index.json` — those are CI's job.
+- Open the PR against `dev`.
+
+## Reference
+
+- Canonical example: `registry/nodes/google-gemini/`
+- Merge logic: `registry/scripts/merge.ts`
+- Build pipeline: `registry/scripts/build-index.ts`
+- CI workflow: `.github/workflows/registry-index.yml`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -44,6 +44,13 @@
 - Provider-specific logic (API calls, credential checks, deploy validation) must live in `packages/provider-[name]`, never in API routes or app code. API routes call methods on the `WorkflowProvider` interface — adding a new provider should only require a new provider package.
 - Route files (`routes/**/*.tsx`) are thin orchestrators — they define the `Route`, render a layout skeleton, and compose sub-components. Business logic, mutations, queries, and non-trivial UI belong in `/components/<domain>/` sub-components. A route file should rarely exceed ~80 lines. Sub-components access Zustand stores directly rather than receiving data through prop drilling from the page.
 
+## Registry Nodes
+
+- **Multi-version nodes use the overrides method — never duplicate `node.json` across versions.** Shared config lives in `registry/nodes/<id>/base.json`; each version contributes a small `registry/nodes/<id>/<version>/overrides.json` with only `version`, `description`, and any fields that change. The canonical example is `registry/nodes/google-gemini/`. Match its file structure 1:1 when bumping or adding a version.
+- Templates are per-version (`<version>/template.ts` or `<version>/templates/<provider>.ts`) — there is no template inheritance. Copy from the previous version and apply the change.
+- **Never run `registry/scripts/build-index.ts` locally.** CI (`.github/workflows/registry-index.yml`) regenerates `<version>/node.json` and `registry/index.json` on push to `main` and opens an auto-merge PR. Do NOT stage `node.json` or `index.json` — only `base.json`, `overrides.json`, and templates.
+- For step-by-step guidance when versioning a node, use the `/version-node` skill.
+
 ## Database Queries (HIGHEST PRIORITY)
 
 - **NEVER chain sequential `await` calls when a single SQL query can do the same work.** If you need data from table A to query table B, use a JOIN — not two round trips. This applies to validation checks (e.g. "fetch project then check membership") — combine them into one query with `INNER JOIN`. Violations of this rule are treated as bugs.

--- a/registry/nodes/direct-mail/1.0.0/overrides.json
+++ b/registry/nodes/direct-mail/1.0.0/overrides.json
@@ -1,0 +1,4 @@
+{
+  "version": "1.0.0",
+  "description": "Send emails via Alibaba Cloud DirectMail API"
+}

--- a/registry/nodes/direct-mail/1.0.1/overrides.json
+++ b/registry/nodes/direct-mail/1.0.1/overrides.json
@@ -1,0 +1,12 @@
+{
+  "version": "1.0.1",
+  "description": "Send emails via Alibaba Cloud DirectMail API with optional sender display name",
+  "configSchema": {
+    "fromAlias": {
+      "type": "string",
+      "label": "From Alias",
+      "placeholder": "Acme Inc.",
+      "description": "Optional sender display name shown to the recipient. Max 15 characters per Alibaba's DirectMail spec."
+    }
+  }
+}

--- a/registry/nodes/direct-mail/1.0.1/template.ts
+++ b/registry/nodes/direct-mail/1.0.1/template.ts
@@ -1,0 +1,85 @@
+export default async function (ctx) {
+  const accessKeyId = ctx.env.ALICLOUD_ACCESS_KEY_ID
+  const accessKeySecret = ctx.env.ALICLOUD_ACCESS_KEY_SECRET
+
+  function percentEncode(str: string): string {
+    return encodeURIComponent(str)
+      .replace(/!/g, '%21')
+      .replace(/'/g, '%27')
+      .replace(/\(/g, '%28')
+      .replace(/\)/g, '%29')
+      .replace(/\*/g, '%2A')
+  }
+
+  async function hmacSha1(key: string, data: string): Promise<string> {
+    const encoder = new TextEncoder()
+    const cryptoKey = await crypto.subtle.importKey(
+      'raw',
+      encoder.encode(key),
+      { name: 'HMAC', hash: 'SHA-1' },
+      false,
+      ['sign'],
+    )
+    const signature = await crypto.subtle.sign('HMAC', cryptoKey, encoder.encode(data))
+    return btoa(String.fromCharCode(...new Uint8Array(signature)))
+  }
+
+  const reqParams: Record<string, string> = {
+    Action: 'SingleSendMail',
+    Format: 'JSON',
+    Version: '2015-11-23',
+    AccessKeyId: accessKeyId,
+    SignatureMethod: 'HMAC-SHA1',
+    SignatureVersion: '1.0',
+    SignatureNonce: crypto.randomUUID(),
+    Timestamp: new Date().toISOString().replace(/\.\d{3}Z$/, 'Z'),
+    AccountName: ctx.config.accountName,
+    AddressType: ctx.config.addressType,
+    ReplyToAddress: ctx.config.replyToAddress !== 'false' ? 'true' : 'false',
+    ToAddress: ctx.config.toAddress,
+    Subject: ctx.config.subject,
+    RegionId: ctx.config.regionId,
+  }
+
+  if (ctx.config.htmlBody) reqParams.HtmlBody = ctx.config.htmlBody
+  if (ctx.config.textBody) reqParams.TextBody = ctx.config.textBody
+  if (ctx.config.fromAlias) reqParams.FromAlias = ctx.config.fromAlias
+
+  const sortedKeys = Object.keys(reqParams).sort()
+  const canonicalQuery = sortedKeys
+    .map((k) => `${percentEncode(k)}=${percentEncode(reqParams[k])}`)
+    .join('&')
+
+  const stringToSign = `POST&${percentEncode('/')}&${percentEncode(canonicalQuery)}`
+  const signature = await hmacSha1(accessKeySecret + '&', stringToSign)
+  reqParams.Signature = signature
+
+  const body = Object.entries(reqParams)
+    .map(([k, v]) => `${encodeURIComponent(k)}=${encodeURIComponent(v)}`)
+    .join('&')
+
+  const endpoint =
+    ctx.config.regionId === 'cn-hangzhou'
+      ? 'dm.aliyuncs.com'
+      : `dm.${ctx.config.regionId}.aliyuncs.com`
+
+  const response = await fetch(`https://${endpoint}/`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+    body,
+  })
+
+  const data = (await response.json()) as Record<string, unknown>
+
+  if (!response.ok) {
+    const code = data.Code ?? 'Unknown'
+    const message = data.Message ?? response.statusText
+    throw new Error(`DirectMail API error (${code}): ${message}`)
+  }
+
+  return {
+    requestId: data.RequestId ?? null,
+    envId: data.EnvId ?? null,
+    data,
+  }
+}

--- a/registry/nodes/direct-mail/base.json
+++ b/registry/nodes/direct-mail/base.json
@@ -1,0 +1,93 @@
+{
+  "id": "direct-mail",
+  "name": "DirectMail",
+  "category": "Email",
+  "icon": "https://raw.githubusercontent.com/awaitstep/awaitstep/main/registry/nodes/direct-mail/icon.svg",
+  "tags": ["alicloud", "directmail", "email", "transactional"],
+  "author": "awaitstep",
+  "license": "Apache-2.0",
+  "configSchema": {
+    "regionId": {
+      "type": "string",
+      "label": "Region ID",
+      "required": true,
+      "placeholder": "cn-hangzhou",
+      "description": "Alibaba Cloud region ID for the DirectMail endpoint."
+    },
+    "accountName": {
+      "type": "string",
+      "label": "Account Name",
+      "required": true,
+      "placeholder": "sender@example.com",
+      "description": "Sender address configured in DirectMail console."
+    },
+    "addressType": {
+      "type": "select",
+      "label": "Address Type",
+      "required": true,
+      "options": ["0", "1"],
+      "description": "0 = random account, 1 = sender address."
+    },
+    "toAddress": {
+      "type": "string",
+      "label": "To Address",
+      "placeholder": "recipient@example.com",
+      "description": "Recipient email address."
+    },
+    "subject": {
+      "type": "string",
+      "label": "Subject",
+      "required": true,
+      "description": "Email subject line."
+    },
+    "htmlBody": {
+      "type": "code",
+      "label": "HTML Body",
+      "description": "HTML email body."
+    },
+    "textBody": {
+      "type": "code",
+      "label": "Text Body",
+      "description": "Plain text email body."
+    },
+    "replyToAddress": {
+      "type": "select",
+      "label": "Reply-To Address",
+      "options": ["true", "false"],
+      "description": "Whether to use the reply-to address. Defaults to true."
+    },
+    "accessKeyId": {
+      "type": "secret",
+      "label": "Access Key ID",
+      "required": true,
+      "envVarName": "ALICLOUD_ACCESS_KEY_ID",
+      "description": "Alibaba Cloud AccessKey ID."
+    },
+    "accessKeySecret": {
+      "type": "secret",
+      "label": "Access Key Secret",
+      "required": true,
+      "envVarName": "ALICLOUD_ACCESS_KEY_SECRET",
+      "description": "Alibaba Cloud AccessKey Secret."
+    }
+  },
+  "outputSchema": {
+    "requestId": {
+      "type": "string",
+      "description": "Alibaba Cloud request ID"
+    },
+    "envId": {
+      "type": "string",
+      "description": "Envelope ID returned by DirectMail"
+    },
+    "data": {
+      "type": "object",
+      "description": "Full API response object"
+    }
+  },
+  "providers": ["cloudflare"],
+  "runtime": {
+    "defaultRetries": 3,
+    "defaultTimeout": "30 seconds"
+  }
+}


### PR DESCRIPTION
## Summary

- **Adds `fromAlias`** as an optional sender display name on the **direct-mail** node, mapped to Alibaba's `FromAlias` API parameter (max 15 chars per their spec). Bumps the node from 1.0.0 → 1.0.1.
- **Migrates direct-mail to the overrides method** (matching `google-gemini`): shared schema in `base.json`, per-version `overrides.json` containing only what changes. No duplicated `node.json` content across versions.
- **Adds a `/version-node` skill** and a new "Registry Nodes" section in `CLAUDE.md` so future contributors follow the same pattern instead of copying full schemas.
- Per project policy, the merged `1.0.1/node.json` and updated `registry/index.json` are **not** committed — CI's `registry-index.yml` workflow regenerates them on push to `main` and opens the auto-merge PR.

## File structure (1:1 with `google-gemini`)

```
registry/nodes/direct-mail/
├── base.json              # NEW: shared schema (sans version/description)
├── icon.svg
├── 1.0.0/
│   ├── node.json          # untouched; CI rewrites on next build
│   ├── overrides.json     # NEW: { version, description }
│   └── template.ts
└── 1.0.1/
    ├── overrides.json     # NEW: version, description, configSchema.fromAlias
    └── template.ts        # NEW: 1.0.0 + one line for FromAlias
```

## Test plan

- [x] `pnpm build` / `pnpm lint` / `pnpm type-check` — all green via husky pre-commit
- [x] JSON parse check on `base.json`, `1.0.0/overrides.json`, `1.0.1/overrides.json`
- [x] Diffed file structure against `registry/nodes/google-gemini/` — identical (modulo CI-generated `1.0.1/node.json`)
- [ ] After merge: confirm CI workflow regenerates `1.0.1/node.json` and `index.json` and that the auto-merge PR lands
- [ ] Manual: deploy a workflow using direct-mail v1.0.1 with `fromAlias: "Acme Inc."` and verify the recipient sees the alias as the sender display name