### PR TITLE
fix(web): script-kind support in import + dashboard New dropdown

### DIFF
--- a/apps/web/src/components/dashboard/import-workflow-dialog.tsx
+++ b/apps/web/src/components/dashboard/import-workflow-dialog.tsx
@@ -3,8 +3,8 @@ import { useNavigate } from '@tanstack/react-router'
 import { useMutation, useQueryClient } from '@tanstack/react-query'
 import { Upload, FileText, AlertCircle, Loader2 } from 'lucide-react'
 import * as Dialog from '@radix-ui/react-dialog'
-import { validateIR } from '@awaitstep/ir'
-import type { WorkflowIR } from '@awaitstep/ir'
+import { validateArtifact } from '@awaitstep/ir'
+import type { ArtifactIR } from '@awaitstep/ir'
 import { Button } from '../ui/button'
 import { CodeEditor } from '../ui/code-editor'
 import { api } from '../../lib/api-client'
@@ -14,7 +14,7 @@ type InputMode = 'paste' | 'file'
 
 function parseAndValidate(
   raw: string,
-): { ir: WorkflowIR; errors: null } | { ir: null; errors: string[] } {
+): { ir: ArtifactIR; errors: null } | { ir: null; errors: string[] } {
   let parsed: unknown
   try {
     parsed = JSON.parse(raw)
@@ -22,7 +22,7 @@ function parseAndValidate(
     return { ir: null, errors: ['Invalid JSON — check for syntax errors.'] }
   }
 
-  const result = validateIR(parsed)
+  const result = validateArtifact(parsed)
   if (!result.ok) {
     return {
       ir: null,
@@ -41,7 +41,7 @@ export function ImportWorkflowDialog({ onClose }: { onClose: () => void }) {
   const [jsonText, setJsonText] = useState('')
   const [fileName, setFileName] = useState<string | null>(null)
   const [name, setName] = useState('')
-  const [validIR, setValidIR] = useState<WorkflowIR | null>(null)
+  const [validIR, setValidIR] = useState<ArtifactIR | null>(null)
   const [errors, setErrors] = useState<string[]>([])
   const [isDragOver, setIsDragOver] = useState(false)
   const fileInputRef = useRef<HTMLInputElement>(null)
@@ -121,22 +121,24 @@ export function ImportWorkflowDialog({ onClose }: { onClose: () => void }) {
       const workflow = await api.createWorkflow({
         name: name.trim() || validIR.metadata.name,
         description: validIR.metadata.description,
+        kind: validIR.kind,
       })
       await api.createVersion(workflow.id, { ir: validIR })
       return workflow
     },
     onSuccess: (workflow) => {
+      const isScript = validIR?.kind === 'script'
       queryClient.invalidateQueries({ queryKey: ['workflows'] })
       navigate({
         to: '/workflows/$workflowId/canvas',
         params: { workflowId: workflow.id },
       }).finally(() => {
-        toast.success('Workflow imported')
+        toast.success(isScript ? 'Function imported' : 'Workflow imported')
         onClose()
       })
     },
     onError: (err) => {
-      toast.error(err instanceof Error ? err.message : 'Failed to import workflow')
+      toast.error(err instanceof Error ? err.message : 'Failed to import')
     },
   })
 
@@ -154,10 +156,12 @@ export function ImportWorkflowDialog({ onClose }: { onClose: () => void }) {
           onDragLeave={() => setIsDragOver(false)}
         >
           <Dialog.Title className="text-base font-semibold text-foreground">
-            Import Workflow
+            Import Workflow or Function
           </Dialog.Title>
           <p className="mt-1 text-xs text-muted-foreground">
-            Paste an IR JSON document or upload an exported <code>.ir.json</code> file.
+            Paste an IR JSON document or upload an exported <code>.ir.json</code> file. The kind (
+            <code>workflow</code> or <code>script</code>) is read from the IR's <code>kind</code>{' '}
+            field; absent <code>kind</code> imports as a workflow.
           </p>
 
           {/* Mode tabs */}
@@ -259,17 +263,28 @@ export function ImportWorkflowDialog({ onClose }: { onClose: () => void }) {
             </div>
           )}
 
-          {/* Workflow name (shown when IR is valid) */}
+          {/* Name + detected kind (shown when IR is valid) */}
           {validIR && (
             <div className="mt-3">
-              <label className="text-xs font-medium text-foreground/60">Workflow name</label>
+              <label className="text-xs font-medium text-foreground/60">
+                {validIR.kind === 'script' ? 'Function name' : 'Workflow name'}
+              </label>
               <input
                 type="text"
                 value={name}
                 onChange={(e) => setName(e.target.value)}
                 className="mt-1 w-full rounded-md border border-border bg-muted/30 px-3 py-2 text-sm text-foreground outline-none focus:border-primary/40"
               />
-              <p className="mt-1.5 text-xs text-muted-foreground">
+              <p className="mt-1.5 flex items-center gap-2 text-xs text-muted-foreground">
+                <span
+                  className={`rounded px-1.5 py-0.5 text-[10px] font-medium uppercase tracking-wide ${
+                    validIR.kind === 'script'
+                      ? 'bg-violet-500/15 text-violet-600 dark:text-violet-300'
+                      : 'bg-emerald-500/15 text-emerald-600 dark:text-emerald-300'
+                  }`}
+                >
+                  {validIR.kind === 'script' ? 'Function' : 'Workflow'}
+                </span>
                 {validIR.nodes.length} nodes, {validIR.edges.length} edges
               </p>
             </div>

--- a/apps/web/src/components/dashboard/new-artifact-dropdown.tsx
+++ b/apps/web/src/components/dashboard/new-artifact-dropdown.tsx
@@ -1,0 +1,68 @@
+import { useNavigate } from '@tanstack/react-router'
+import { ChevronDown, Plus, Workflow, Zap } from 'lucide-react'
+import { Button } from '../ui/button'
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from '../ui/dropdown-menu'
+import { useSheetStore } from '../../stores/sheet-store'
+import { NEW_FUNCTION_NAV, NEW_WORKFLOW_NAV } from '../../lib/nav'
+
+interface NewArtifactDropdownProps {
+  size?: 'sm' | 'default'
+}
+
+/**
+ * The "New" button shared between the workflows index page and the dashboard
+ * workflow list. Surfaces both artifact kinds (Workflow + Function) so users
+ * can discover Function creation from either entry point.
+ */
+export function NewArtifactDropdown({ size = 'sm' }: NewArtifactDropdownProps) {
+  const navigate = useNavigate()
+  const { guardAction } = useSheetStore()
+
+  const goNew = (target: 'workflow' | 'function') => {
+    guardAction('project', () =>
+      navigate(target === 'function' ? NEW_FUNCTION_NAV : NEW_WORKFLOW_NAV),
+    )
+  }
+
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger asChild>
+        <Button size={size} className="gap-1.5">
+          <Plus className="h-4 w-4" />
+          New
+          <ChevronDown className="h-4 w-4 opacity-70" />
+        </Button>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent align="end" className="w-72">
+        <DropdownMenuItem onSelect={() => goNew('workflow')}>
+          <Workflow className="h-4 w-4" />
+          <div className="flex flex-col">
+            <span>Workflow</span>
+            <span className="text-xs text-muted-foreground">
+              Durable, multi-step, with sleeps and waits
+            </span>
+          </div>
+        </DropdownMenuItem>
+        <DropdownMenuItem onSelect={() => goNew('function')}>
+          <Zap className="h-4 w-4" />
+          <div className="flex flex-col">
+            <span className="flex items-center gap-1.5">
+              Function
+              <span className="rounded bg-primary/10 px-1 py-0.5 text-[9px] font-semibold uppercase tracking-wide text-primary">
+                Beta
+              </span>
+            </span>
+            <span className="text-xs text-muted-foreground">
+              Stateless, runs synchronously, returns immediately
+            </span>
+          </div>
+        </DropdownMenuItem>
+      </DropdownMenuContent>
+    </DropdownMenu>
+  )
+}

--- a/apps/web/src/components/dashboard/workflow-actions-menu.tsx
+++ b/apps/web/src/components/dashboard/workflow-actions-menu.tsx
@@ -61,6 +61,7 @@ export function WorkflowActionsMenu({ workflow, isDeployed }: WorkflowActionsMen
       const newWf = await api.createWorkflow({
         name: `${workflow.name} (copy)`,
         description: workflow.description,
+        kind: workflow.kind,
       })
       if (workflow.currentVersionId) {
         const ver = await api.getVersion(workflow.id, workflow.currentVersionId)

--- a/apps/web/src/components/dashboard/workflow-list.tsx
+++ b/apps/web/src/components/dashboard/workflow-list.tsx
@@ -1,5 +1,5 @@
 import { Link } from '@tanstack/react-router'
-import { Plus } from 'lucide-react'
+import { Plus, Workflow } from 'lucide-react'
 import { Button, buttonVariants } from '../ui/button'
 import { GuardedLink } from '../ui/guarded-link'
 import type { WorkflowSummary } from '../../lib/api-client'
@@ -7,12 +7,12 @@ import { useWorkflowsStore } from '../../stores/workflows-store'
 import { WorkflowStatusBadge } from './workflow-status-badge'
 import { WorkflowActionsMenu } from './workflow-actions-menu'
 import { TriggerButton } from './trigger-button'
+import { NewArtifactDropdown } from './new-artifact-dropdown'
 import { timeAgo } from '../../lib/time'
 import { NEW_WORKFLOW_NAV } from '../../lib/nav'
 import { useShallow } from 'zustand/react/shallow'
 import { LoadingView } from '../ui/loading-view'
 import { EmptyState } from '../ui/empty-state'
-import { Workflow } from 'lucide-react'
 
 export function WorkflowList() {
   const { workflows, isLoading, hasMore } = useWorkflowsStore(
@@ -37,14 +37,7 @@ export function WorkflowList() {
               </Button>
             </Link>
           )}
-          <GuardedLink
-            className={buttonVariants({ size: 'sm' })}
-            requirement="project"
-            nav={NEW_WORKFLOW_NAV}
-          >
-            <Plus className="h-4 w-4" />
-            New Workflow
-          </GuardedLink>
+          <NewArtifactDropdown />
         </div>
       </div>
 

--- a/apps/web/src/routes/_authed/workflows.index.tsx
+++ b/apps/web/src/routes/_authed/workflows.index.tsx
@@ -1,24 +1,18 @@
-import { createFileRoute, Link, useNavigate } from '@tanstack/react-router'
-import { ChevronDown, Plus, Search, Upload, Workflow, Zap } from 'lucide-react'
+import { createFileRoute, Link } from '@tanstack/react-router'
+import { Plus, Search, Upload, Workflow } from 'lucide-react'
 import { useState, useMemo } from 'react'
 import { Button } from '../../components/ui/button'
 import { GuardedLink } from '../../components/ui/guarded-link'
-import {
-  DropdownMenu,
-  DropdownMenuContent,
-  DropdownMenuItem,
-  DropdownMenuTrigger,
-} from '../../components/ui/dropdown-menu'
 import { PageHeader } from '../../components/ui/page-header'
 import type { WorkflowSummary } from '../../lib/api-client'
 import { useWorkflowsStore } from '../../stores/workflows-store'
-import { useSheetStore } from '../../stores/sheet-store'
 import { WorkflowActionsMenu } from '../../components/dashboard/workflow-actions-menu'
 import { TriggerButton } from '../../components/dashboard/trigger-button'
 import { ImportWorkflowDialog } from '../../components/dashboard/import-workflow-dialog'
+import { NewArtifactDropdown } from '../../components/dashboard/new-artifact-dropdown'
 import { timeAgo } from '../../lib/time'
 import { RequireProject } from '../../wrappers/require-project'
-import { NEW_FUNCTION_NAV, NEW_WORKFLOW_NAV } from '../../lib/nav'
+import { NEW_WORKFLOW_NAV } from '../../lib/nav'
 import { LoadingView } from '../../components/ui/loading-view'
 import { LoadMoreButton } from '../../components/ui/load-more-button'
 import { ListSkeleton } from '../../components/ui/skeletons'
@@ -38,8 +32,6 @@ function WorkflowsIndexPage() {
 }
 
 function WorkflowsIndexContent() {
-  const navigate = useNavigate()
-  const { guardAction } = useSheetStore()
   const workflows = useWorkflowsStore((s) => s.workflows)
   const isLoading = useWorkflowsStore((s) => s.fetchState === 'idle' || s.fetchState === 'loading')
   const hasMore = useWorkflowsStore((s) => s.hasMore)
@@ -47,12 +39,6 @@ function WorkflowsIndexContent() {
   const isFetchingMore = useWorkflowsStore((s) => s.isFetchingMore)
   const [search, setSearch] = useState('')
   const [importOpen, setImportOpen] = useState(false)
-
-  const goNew = (target: 'workflow' | 'function') => {
-    guardAction('project', () =>
-      navigate(target === 'function' ? NEW_FUNCTION_NAV : NEW_WORKFLOW_NAV),
-    )
-  }
 
   const filtered = useMemo(() => {
     if (!search.trim()) return workflows
@@ -78,40 +64,7 @@ function WorkflowsIndexContent() {
               <Upload className="h-4 w-4" />
               Import
             </Button>
-            <DropdownMenu>
-              <DropdownMenuTrigger asChild>
-                <Button size="sm" className="gap-1.5">
-                  <Plus className="h-4 w-4" />
-                  New
-                  <ChevronDown className="h-4 w-4 opacity-70" />
-                </Button>
-              </DropdownMenuTrigger>
-              <DropdownMenuContent align="end" className="w-72">
-                <DropdownMenuItem onSelect={() => goNew('workflow')}>
-                  <Workflow className="h-4 w-4" />
-                  <div className="flex flex-col">
-                    <span>Workflow</span>
-                    <span className="text-xs text-muted-foreground">
-                      Durable, multi-step, with sleeps and waits
-                    </span>
-                  </div>
-                </DropdownMenuItem>
-                <DropdownMenuItem onSelect={() => goNew('function')}>
-                  <Zap className="h-4 w-4" />
-                  <div className="flex flex-col">
-                    <span className="flex items-center gap-1.5">
-                      Function
-                      <span className="rounded bg-primary/10 px-1 py-0.5 text-[9px] font-semibold uppercase tracking-wide text-primary">
-                        Beta
-                      </span>
-                    </span>
-                    <span className="text-xs text-muted-foreground">
-                      Stateless, runs synchronously, returns immediately
-                    </span>
-                  </div>
-                </DropdownMenuItem>
-              </DropdownMenuContent>
-            </DropdownMenu>
+            <NewArtifactDropdown />
           </div>
         }
       />


### PR DESCRIPTION
## Summary

Two follow-ups on the scripts primitive after a real-world test caught the gaps:

- **Import dialog rejected scripts.** `validateIR` (workflow-only) was used instead of `validateArtifact`, so any pasted IR with `kind: "script"` failed schema validation. Same fix for **Duplicate** in the workflow actions menu — neither path passed `kind` to `api.createWorkflow`, which would have silently demoted scripts to workflows on round-trip.
- **Dashboard "New Workflow" button** went straight to `NEW_WORKFLOW_NAV`, hiding Function creation behind the `/workflows` index page. Extracted the existing dropdown JSX into a shared `NewArtifactDropdown` and used it from both surfaces.

## Test plan

- [ ] `pnpm test` / `pnpm build` / `pnpm lint` / `pnpm type-check` green
- [ ] Manual: paste the user-reported `kind: "script"` IR into the Import dialog → validates → "Function" badge appears in preview → "Function imported" toast on success
- [ ] Manual: import a workflow IR (no `kind` field) → still validates and imports as a workflow
- [ ] Manual: duplicate a deployed Function from the actions menu → new row's kind matches; the canvas shows the Function badge
- [ ] Manual: dashboard `/dashboard` shows the "New" dropdown with Workflow + Function (Beta) options; both create the right artifact