### PR TITLE
fix(docs): render {{ expressions correctly across public site

### DIFF
--- a/apps/docs/api/ir-schema.md
+++ b/apps/docs/api/ir-schema.md
@@ -148,8 +148,8 @@ Nodes marked ❌ for script require a durable runtime and are rejected by `valid
       "data": {
         "method": "POST",
         "url": "https://api.resend.com/emails",
-        "headers": "{\"Authorization\": \"Bearer &#123;&#123;env.RESEND_API_KEY&#125;&#125;\"}",
-        "body": "{\"to\": \"&#123;&#123;parse_order.email&#125;&#125;\", \"subject\": \"Order confirmed\"}"
+        "headers": "{\"Authorization\": \"Bearer {{env.RESEND_API_KEY}}\"}",
+        "body": "{\"to\": \"{{parse_order.email}}\", \"subject\": \"Order confirmed\"}"
       },
       "config": {
         "retries": { "limit": 3, "delay": "10 seconds", "backoff": "exponential" }
@@ -190,7 +190,7 @@ The platform validates the IR (schema + expression references + cycle detection)
 - `entryNodeId` must reference a node that exists in `nodes`.
 - All `edges` must reference node IDs that exist in `nodes`.
 - No cycles in the edge graph (DAG constraint).
-- Expression references (`<span v-pre>&#123;&#123;nodeId.path&#125;&#125;</span>`) must point to upstream nodes only.
+- Expression references (<code v-pre>{{nodeId.path}}</code>) must point to upstream nodes only.
 - `select`/`multiselect` field values must be one of the declared `options`.
 - Duration strings must be parseable (e.g. `"30 seconds"`, `"2 hours"`).
 

--- a/apps/docs/api/webhooks.md
+++ b/apps/docs/api/webhooks.md
@@ -17,12 +17,12 @@ If you need to be notified when a run finishes, you have two options:
 
 Add an **HTTP Request** node as the last step in your workflow:
 
-| Field   | Value                                                                                       |
-| ------- | ------------------------------------------------------------------------------------------- |
-| Method  | `POST`                                                                                      |
-| URL     | `https://your-server.example.com/webhooks/workflow-complete`                                |
-| Headers | `{"Authorization": "Bearer <span v-pre>&#123;&#123;env.WEBHOOK_SECRET&#125;&#125;</span>"}` |
-| Body    | `{"workflowId": "...", "status": "complete"}`                                               |
+| Field   | Value                                                                 |
+| ------- | --------------------------------------------------------------------- |
+| Method  | `POST`                                                                |
+| URL     | `https://your-server.example.com/webhooks/workflow-complete`          |
+| Headers | <code v-pre>{"Authorization": "Bearer {{env.WEBHOOK_SECRET}}"}</code> |
+| Body    | `{"workflowId": "...", "status": "complete"}`                         |
 
 This gives you full control over the payload and authentication.
 

--- a/apps/docs/building-workflows/error-handling.md
+++ b/apps/docs/building-workflows/error-handling.md
@@ -74,7 +74,7 @@ try {
 ```
 
 :::tip
-The `err` variable inside the catch branch is available as `err.message` in expressions. Reference it with `<span v-pre>&#123;&#123;try_catch_node.error&#125;&#125;</span>` — the exact path depends on what the catch step returns.
+The `err` variable inside the catch branch is available as `err.message` in expressions. Reference it with <code v-pre>{{try_catch_node.error}}</code> — the exact path depends on what the catch step returns.
 :::
 
 ## NonRetryableError

--- a/apps/docs/building-workflows/expressions.md
+++ b/apps/docs/building-workflows/expressions.md
@@ -4,14 +4,14 @@ title: Expressions
 
 # Expressions
 
-Expressions let you pass data from one step to another without writing glue code. They use a `<span v-pre>&#123;&#123;nodeId.property&#125;&#125;</span>` syntax that is resolved at code generation time.
+Expressions let you pass data from one step to another without writing glue code. They use a <code v-pre>{{nodeId.property}}</code> syntax that is resolved at code generation time.
 
 ## Syntax
 
 ```
-&#123;&#123;nodeId.property&#125;&#125;
-&#123;&#123;nodeId.nested.property&#125;&#125;
-&#123;&#123;nodeId.arrayField[0].name&#125;&#125;
+{{nodeId.property}}
+{{nodeId.nested.property}}
+{{nodeId.arrayField[0].name}}
 ```
 
 - `nodeId` — the ID of an upstream node (shown in the node config drawer)
@@ -21,15 +21,15 @@ Expressions let you pass data from one step to another without writing glue code
 
 Expressions can be used in any config field of type `string`, `expression`, or `textarea`. They are also used in Branch conditions and Loop collection fields.
 
-| Field type   | Expression support                                                                                  |
-| ------------ | --------------------------------------------------------------------------------------------------- |
-| `string`     | Yes — embedded in the value, e.g. `Hello <span v-pre>&#123;&#123;user_step.name&#125;&#125;</span>` |
-| `expression` | Yes — the entire value is an expression                                                             |
-| `textarea`   | Yes — embedded in multi-line text                                                                   |
-| `number`     | No — use a Step node to compute numeric values                                                      |
-| `select`     | No — options are fixed at design time                                                               |
-| `secret`     | No — secrets bind to env vars, not upstream outputs                                                 |
-| `code`       | Yes — reference upstream vars directly by name in JavaScript                                        |
+| Field type   | Expression support                                                            |
+| ------------ | ----------------------------------------------------------------------------- |
+| `string`     | Yes — embedded in the value, e.g. <code v-pre>Hello {{user_step.name}}</code> |
+| `expression` | Yes — the entire value is an expression                                       |
+| `textarea`   | Yes — embedded in multi-line text                                             |
+| `number`     | No — use a Step node to compute numeric values                                |
+| `select`     | No — options are fixed at design time                                         |
+| `secret`     | No — secrets bind to env vars, not upstream outputs                           |
+| `code`       | Yes — reference upstream vars directly by name in JavaScript                  |
 
 ## Examples
 
@@ -38,7 +38,7 @@ Expressions can be used in any config field of type `string`, `expression`, or `
 In a **Send Email** node's "To" field:
 
 ```
-&#123;&#123;create_user.email&#125;&#125;
+{{create_user.email}}
 ```
 
 This resolves to the `email` property of the `create_user` step's return value.
@@ -46,7 +46,7 @@ This resolves to the `email` property of the `create_user` step's return value.
 ### Nested property access
 
 ```
-&#123;&#123;parse_webhook.body.order.id&#125;&#125;
+{{parse_webhook.body.order.id}}
 ```
 
 ### Embedding in text
@@ -54,18 +54,18 @@ This resolves to the `email` property of the `create_user` step's return value.
 In a message body field:
 
 ```
-Hello &#123;&#123;user.firstName&#125;&#125;, your order &#123;&#123;place_order.orderId&#125;&#125; has been confirmed.
+Hello {{user.firstName}}, your order {{place_order.orderId}} has been confirmed.
 ```
 
 ## How expressions resolve
 
-At code-generation time, `<span v-pre>&#123;&#123;nodeId.property&#125;&#125;</span>` is replaced with a JavaScript property access on the step result variable:
+At code-generation time, <code v-pre>{{nodeId.property}}</code> is replaced with a JavaScript property access on the step result variable:
 
 ```typescript
-// &#123;&#123;create_user.email&#125;&#125; becomes:
+// {{create_user.email}} becomes:
 create_user.email
 
-// &#123;&#123;parse_webhook.body.order.id&#125;&#125; becomes:
+// {{parse_webhook.body.order.id}} becomes:
 parse_webhook.body.order.id
 ```
 
@@ -79,7 +79,7 @@ await step.do(`Send email to ${create_user.email}`, async () => {
 
 ## Autocomplete
 
-In config fields that support expressions, the UI provides autocomplete. After typing `&#123;&#123;`, a dropdown shows all upstream nodes and their typed output fields. Navigate with arrow keys and press Enter to insert.
+In config fields that support expressions, the UI provides autocomplete. After typing <code v-pre>{{</code>, a dropdown shows all upstream nodes and their typed output fields. Navigate with arrow keys and press Enter to insert.
 
 The autocomplete tree mirrors the `outputSchema` of each node definition.
 
@@ -109,4 +109,4 @@ return {
 }
 ```
 
-Then reference `<span v-pre>&#123;&#123;parse_trigger.orderId&#125;&#125;</span>` in downstream nodes.
+Then reference <code v-pre>{{parse_trigger.orderId}}</code> in downstream nodes.

--- a/apps/docs/building-workflows/sequential.md
+++ b/apps/docs/building-workflows/sequential.md
@@ -19,10 +19,10 @@ The workflow below has two steps:
 
 ### Canvas nodes
 
-| Order | Node name      | Node type          | Key config                                                            |
-| ----- | -------------- | ------------------ | --------------------------------------------------------------------- |
-| 1     | Validate Input | Step               | Custom TypeScript                                                     |
-| 2     | Send Email     | Resend: Send Email | to: `<span v-pre>&#123;&#123;validate_input.email&#125;&#125;</span>` |
+| Order | Node name      | Node type          | Key config                                      |
+| ----- | -------------- | ------------------ | ----------------------------------------------- |
+| 1     | Validate Input | Step               | Custom TypeScript                               |
+| 2     | Send Email     | Resend: Send Email | to: <code v-pre>{{validate_input.email}}</code> |
 
 ### Generated TypeScript
 

--- a/apps/docs/building-workflows/sleeping.md
+++ b/apps/docs/building-workflows/sleeping.md
@@ -37,7 +37,7 @@ The **Sleep Until** node pauses until a specific timestamp.
 The timestamp can be a static value or an expression referencing an upstream step output:
 
 ```
-&#123;&#123;parse_schedule.scheduledAt&#125;&#125;
+{{parse_schedule.scheduledAt}}
 ```
 
 ### Generated code

--- a/apps/docs/concepts/canvas.md
+++ b/apps/docs/concepts/canvas.md
@@ -26,26 +26,26 @@ Selecting a node opens the config panel in the right sidebar. The config panel r
 
 Each field type renders a different control:
 
-| Type          | Control                                                                                   |
-| ------------- | ----------------------------------------------------------------------------------------- |
-| `string`      | Single-line text input                                                                    |
-| `number`      | Numeric input with min/max validation                                                     |
-| `boolean`     | Toggle switch                                                                             |
-| `select`      | Dropdown with predefined options                                                          |
-| `multiselect` | Multi-select dropdown                                                                     |
-| `secret`      | Masked input that binds to an environment variable                                        |
-| `code`        | Monaco editor in TypeScript mode                                                          |
-| `json`        | Monaco editor in JSON mode                                                                |
-| `expression`  | Text input with `<span v-pre>&#123;&#123;nodeId.property&#125;&#125;</span>` autocomplete |
-| `textarea`    | Multi-line text area                                                                      |
+| Type          | Control                                                             |
+| ------------- | ------------------------------------------------------------------- |
+| `string`      | Single-line text input                                              |
+| `number`      | Numeric input with min/max validation                               |
+| `boolean`     | Toggle switch                                                       |
+| `select`      | Dropdown with predefined options                                    |
+| `multiselect` | Multi-select dropdown                                               |
+| `secret`      | Masked input that binds to an environment variable                  |
+| `code`        | Monaco editor in TypeScript mode                                    |
+| `json`        | Monaco editor in JSON mode                                          |
+| `expression`  | Text input with <code v-pre>{{nodeId.property}}</code> autocomplete |
+| `textarea`    | Multi-line text area                                                |
 
 ### Expression Autocomplete
 
-Fields of type `expression` provide autocomplete for the outputs of upstream nodes. Type `&#123;&#123;` to trigger the suggestion popup. Suggestions are drawn from the `outputSchema` of each upstream node.
+Fields of type `expression` provide autocomplete for the outputs of upstream nodes. Type <code v-pre>{{</code> to trigger the suggestion popup. Suggestions are drawn from the `outputSchema` of each upstream node.
 
 ```
-&#123;&#123;fetch_user.email&#125;&#125;
-&#123;&#123;charge_result.amount&#125;&#125;
+{{fetch_user.email}}
+{{charge_result.amount}}
 ```
 
 Only nodes that are topologically upstream of the current node appear in autocomplete. The editor shows an error indicator if an expression references a downstream node or a node that does not exist.

--- a/apps/docs/concepts/compilation.md
+++ b/apps/docs/concepts/compilation.md
@@ -25,7 +25,7 @@ Before any code is generated, the IR is passed through `validateIR` from `@await
 
 - **Schema validation** — all required fields present, all types correct (via Zod schemas)
 - **Graph validation** — entry node exists, all edges reference valid node IDs, no orphaned nodes
-- **Expression validation** — all `<span v-pre>&#123;&#123;nodeId.property&#125;&#125;</span>` expressions reference existing upstream nodes
+- **Expression validation** — all <code v-pre>{{nodeId.property}}</code> expressions reference existing upstream nodes
 - **Config validation** — required config fields are present for each node
 
 ```typescript
@@ -138,10 +138,10 @@ if (fetch_user_result.status === 200) {
 
 ### Expression Resolution
 
-During code generation, `<span v-pre>&#123;&#123;nodeId.property&#125;&#125;</span>` expressions in config values are resolved to direct JavaScript property accesses:
+During code generation, <code v-pre>{{nodeId.property}}</code> expressions in config values are resolved to direct JavaScript property accesses:
 
 ```typescript
-// Config value: "&#123;&#123;fetch_user_result.body&#125;&#125;"
+// Config value: "{{fetch_user_result.body}}"
 // Resolved to:  fetch_user_result.body
 ```
 

--- a/apps/docs/concepts/workflow-ir.md
+++ b/apps/docs/concepts/workflow-ir.md
@@ -145,12 +145,12 @@ In script mode, `sub_workflow` is always fire-and-forget — there is no durable
 
 ## Expression System
 
-Nodes can reference the output of upstream nodes using the `<span v-pre>&#123;&#123;nodeId.property&#125;&#125;</span>` expression syntax. Expressions are valid in any `expression`-typed config field and are resolved by the codegen pipeline at build time.
+Nodes can reference the output of upstream nodes using the <code v-pre>{{nodeId.property}}</code> expression syntax. Expressions are valid in any `expression`-typed config field and are resolved by the codegen pipeline at build time.
 
 ### Syntax
 
 ```
-&#123;&#123;nodeId.property.nestedProperty&#125;&#125;
+{{nodeId.property.nestedProperty}}
 ```
 
 - `nodeId` — the `id` of an upstream `WorkflowNode`
@@ -160,18 +160,18 @@ Nodes can reference the output of upstream nodes using the `<span v-pre>&#123;&#
 ### Examples
 
 ```
-&#123;&#123;fetch_user.email&#125;&#125;
-&#123;&#123;charge_result.amount&#125;&#125;
-&#123;&#123;get_orders.results.0.id&#125;&#125;
+{{fetch_user.email}}
+{{charge_result.amount}}
+{{get_orders.results.0.id}}
 ```
 
 ### How Expressions Are Resolved
 
-The codegen pipeline performs a topological sort of the DAG and assigns each node a JavaScript variable name. At code generation time, `<span v-pre>&#123;&#123;nodeId.property&#125;&#125;</span>` becomes a direct JavaScript property access:
+The codegen pipeline performs a topological sort of the DAG and assigns each node a JavaScript variable name. At code generation time, <code v-pre>{{nodeId.property}}</code> becomes a direct JavaScript property access:
 
 ```typescript
 // Before resolution (in IR data field):
-"to": "&#123;&#123;fetch_user.email&#125;&#125;"
+"to": "{{fetch_user.email}}"
 
 // After resolution (in generated worker code):
 const sendEmail_result = await step.do('sendEmail', async () => {
@@ -209,7 +209,7 @@ The IR validator checks that:
       "provider": "cloudflare",
       "data": {
         "method": "GET",
-        "url": "https://api.example.com/users/&#123;&#123;trigger.userId&#125;&#125;"
+        "url": "https://api.example.com/users/{{trigger.userId}}"
       }
     },
     {
@@ -220,7 +220,7 @@ The IR validator checks that:
       "version": "1.0.0",
       "provider": "cloudflare",
       "data": {
-        "to": "&#123;&#123;fetch_user.body&#125;&#125;",
+        "to": "{{fetch_user.body}}",
         "subject": "Welcome!"
       }
     }

--- a/apps/docs/contributing/project-structure.md
+++ b/apps/docs/contributing/project-structure.md
@@ -55,14 +55,14 @@ The React SPA. Key directories:
 
 The IR package defines the Workflow IR types and all logic that operates on them:
 
-| File                     | Purpose                                                                                   |
-| ------------------------ | ----------------------------------------------------------------------------------------- |
-| `src/types.ts`           | `WorkflowIR`, `WorkflowNode`, `Edge`, `TriggerConfig` types                               |
-| `src/schema.ts`          | Zod validation schema                                                                     |
-| `src/validate.ts`        | Semantic validation (cycle detection, expression checks)                                  |
-| `src/expressions.ts`     | Expression parser and resolver (`<span v-pre>&#123;&#123;nodeId.path&#125;&#125;</span>`) |
-| `src/node-definition.ts` | `NodeDefinition`, `ConfigField`, `OutputField` types                                      |
-| `src/bundled-nodes/`     | Built-in node definitions (http_request, etc.)                                            |
+| File                     | Purpose                                                             |
+| ------------------------ | ------------------------------------------------------------------- |
+| `src/types.ts`           | `WorkflowIR`, `WorkflowNode`, `Edge`, `TriggerConfig` types         |
+| `src/schema.ts`          | Zod validation schema                                               |
+| `src/validate.ts`        | Semantic validation (cycle detection, expression checks)            |
+| `src/expressions.ts`     | Expression parser and resolver (<code v-pre>{{nodeId.path}}</code>) |
+| `src/node-definition.ts` | `NodeDefinition`, `ConfigField`, `OutputField` types                |
+| `src/bundled-nodes/`     | Built-in node definitions (http_request, etc.)                      |
 
 ## packages/codegen
 

--- a/apps/docs/nodes/custom-nodes.md
+++ b/apps/docs/nodes/custom-nodes.md
@@ -68,7 +68,7 @@ nodes/
       "type": "expression",
       "label": "Customer ID",
       "required": true,
-      "placeholder": "&#123;&#123;fetch_customer.id&#125;&#125;"
+      "placeholder": "{{fetch_customer.id}}"
     },
     "apiKey": {
       "type": "secret",
@@ -183,7 +183,7 @@ export default async function (ctx: NodeContext<Config>): Promise<Output> {
 
 ## Output Schema
 
-The `outputSchema` types the node's return value. Downstream nodes can reference fields via `<span v-pre>&#123;&#123;nodeId.fieldName&#125;&#125;</span>`.
+The `outputSchema` types the node's return value. Downstream nodes can reference fields via <code v-pre>{{nodeId.fieldName}}</code>.
 
 ```json
 {

--- a/apps/docs/nodes/overview.md
+++ b/apps/docs/nodes/overview.md
@@ -4,7 +4,7 @@ A node is a reusable, self-describing workflow building block. Every node on the
 
 - **What it does** — a name, description, and category
 - **What it needs** — a config schema that drives the UI form automatically
-- **What it produces** — a typed output schema that downstream nodes can reference via `<span v-pre>&#123;&#123;nodeId.property&#125;&#125;</span>`
+- **What it produces** — a typed output schema that downstream nodes can reference via <code v-pre>{{nodeId.property}}</code>
 - **How it runs** — one or more code templates, one per execution provider
 
 Every node is automatically wrapped in `step.do()` by the compile pipeline. You never write retry or durability logic — the platform handles it.

--- a/apps/docs/troubleshooting/deploy-failures.md
+++ b/apps/docs/troubleshooting/deploy-failures.md
@@ -60,7 +60,7 @@ See [Wrangler Errors](./wrangler-errors.md) for more wrangler-specific issues.
 
 **Fix:** The deploy response includes a list of validation errors with node IDs and paths. Open the canvas and address each error:
 
-- Fix broken expression references (`<span v-pre>&#123;&#123;unknownNode.field&#125;&#125;</span>` pointing to a removed node).
+- Fix broken expression references (<code v-pre>{{unknownNode.field}}</code> pointing to a removed node).
 - Connect all nodes — every node must be reachable from the entry node.
 - Check that `select` fields have a valid option selected.
 

--- a/apps/docs/troubleshooting/wrangler-errors.md
+++ b/apps/docs/troubleshooting/wrangler-errors.md
@@ -107,7 +107,7 @@ Worker names are derived from the workflow name and the `APP_NAME` env var.
 
 1. Click **View Generated Code** in the workflow toolbar (or fetch the version via API).
 2. Review the generated TypeScript for obvious errors.
-3. Check that all `<span v-pre>&#123;&#123;expression&#125;&#125;</span>` references resolve to the correct values.
+3. Check that all <code v-pre>{{expression}}</code> references resolve to the correct values.
 4. Add console.log statements to Step nodes to debug (visible in Cloudflare Worker logs). Remove them before the final deploy.
 
 ---


### PR DESCRIPTION
## Summary

The user pointed out (with a screenshot of the workflow-ir Examples section) that `{{` and `}}` were rendering as literal `&#123;` and `&#125;` text in the public docs.

Two layered bugs caused this:

1. **In fenced code blocks**, the docs used HTML entities `&#123;&#123;` to dodge Vue's `{{ }}` interpolation. But markdown-it escapes `&` inside code (`&` → `&amp;`), so the entity never decoded — users saw the literal entity text.
2. **In prose**, the entities were wrapped in `` `<span v-pre>...</span>` `` (inline backticks around an HTML span). markdown-it escapes the `<span>` tag to text inside inline code, so v-pre never attached to a real element. The entities still rendered as literal text — same broken output, different mechanism.

Fix:

- Inside fenced code blocks: literal `{{ }}`. VitePress applies v-pre semantics to fenced blocks, so Vue doesn't interpolate.
- In prose: replace the `` `<span v-pre>...</span>` `` pattern with raw-HTML `<code v-pre>...</code>`. v-pre now attaches to an actual DOM element. The bare ``\`{{\``` cases (`Type \`{{\` to trigger`) get the same treatment — `<code v-pre>{{</code>`.

Without (2), replacing entities with literals in the bare-prose paths caused VitePress' Vue compile step to fail outright with "Error parsing JavaScript expression". Verified — the previous `vitepress build` broke; now passes in ~17s.

## Test plan

- [x] `pnpm --filter @awaitstep/docs build` succeeds
- [ ] Manually skim the rendered preview (`vitepress preview`) for the affected pages and confirm `{{ }}` shows as expected:
  - Concepts → Workflow & Script IR (Examples section)
  - Concepts → Canvas (Expression Autocomplete)
  - Concepts → Compilation
  - API → REST API + IR Schema + Triggers + Webhooks
  - Building Workflows → Expressions, Sequential, Sleeping, Error Handling
  - Nodes → Overview, Custom Nodes
  - Troubleshooting → Wrangler Errors, Deploy Failures
  - Contributing → Project Structure