### PR TITLE
fix: imports and docs expression rendering

### DIFF
--- a/apps/docs/api/ir-schema.md
+++ b/apps/docs/api/ir-schema.md
@@ -148,8 +148,8 @@ Nodes marked ❌ for script require a durable runtime and are rejected by `valid
       "data": {
         "method": "POST",
         "url": "https://api.resend.com/emails",
-        "headers": "{\"Authorization\": \"Bearer &#123;&#123;env.RESEND_API_KEY&#125;&#125;\"}",
-        "body": "{\"to\": \"&#123;&#123;parse_order.email&#125;&#125;\", \"subject\": \"Order confirmed\"}"
+        "headers": "{\"Authorization\": \"Bearer {{env.RESEND_API_KEY}}\"}",
+        "body": "{\"to\": \"{{parse_order.email}}\", \"subject\": \"Order confirmed\"}"
       },
       "config": {
         "retries": { "limit": 3, "delay": "10 seconds", "backoff": "exponential" }
@@ -190,7 +190,7 @@ The platform validates the IR (schema + expression references + cycle detection)
 - `entryNodeId` must reference a node that exists in `nodes`.
 - All `edges` must reference node IDs that exist in `nodes`.
 - No cycles in the edge graph (DAG constraint).
-- Expression references (`<span v-pre>&#123;&#123;nodeId.path&#125;&#125;</span>`) must point to upstream nodes only.
+- Expression references (<code v-pre>{{nodeId.path}}</code>) must point to upstream nodes only.
 - `select`/`multiselect` field values must be one of the declared `options`.
 - Duration strings must be parseable (e.g. `"30 seconds"`, `"2 hours"`).
 

--- a/apps/docs/api/webhooks.md
+++ b/apps/docs/api/webhooks.md
@@ -17,12 +17,12 @@ If you need to be notified when a run finishes, you have two options:
 
 Add an **HTTP Request** node as the last step in your workflow:
 
-| Field   | Value                                                                                       |
-| ------- | ------------------------------------------------------------------------------------------- |
-| Method  | `POST`                                                                                      |
-| URL     | `https://your-server.example.com/webhooks/workflow-complete`                                |
-| Headers | `{"Authorization": "Bearer <span v-pre>&#123;&#123;env.WEBHOOK_SECRET&#125;&#125;</span>"}` |
-| Body    | `{"workflowId": "...", "status": "complete"}`                                               |
+| Field   | Value                                                                 |
+| ------- | --------------------------------------------------------------------- |
+| Method  | `POST`                                                                |
+| URL     | `https://your-server.example.com/webhooks/workflow-complete`          |
+| Headers | <code v-pre>{"Authorization": "Bearer {{env.WEBHOOK_SECRET}}"}</code> |
+| Body    | `{"workflowId": "...", "status": "complete"}`                         |
 
 This gives you full control over the payload and authentication.
 

--- a/apps/docs/building-workflows/error-handling.md
+++ b/apps/docs/building-workflows/error-handling.md
@@ -74,7 +74,7 @@ try {
 ```
 
 :::tip
-The `err` variable inside the catch branch is available as `err.message` in expressions. Reference it with `<span v-pre>&#123;&#123;try_catch_node.error&#125;&#125;</span>` — the exact path depends on what the catch step returns.
+The `err` variable inside the catch branch is available as `err.message` in expressions. Reference it with <code v-pre>{{try_catch_node.error}}</code> — the exact path depends on what the catch step returns.
 :::
 
 ## NonRetryableError

--- a/apps/docs/building-workflows/expressions.md
+++ b/apps/docs/building-workflows/expressions.md
@@ -4,14 +4,14 @@ title: Expressions
 
 # Expressions
 
-Expressions let you pass data from one step to another without writing glue code. They use a `<span v-pre>&#123;&#123;nodeId.property&#125;&#125;</span>` syntax that is resolved at code generation time.
+Expressions let you pass data from one step to another without writing glue code. They use a <code v-pre>{{nodeId.property}}</code> syntax that is resolved at code generation time.
 
 ## Syntax
 
 ```
-&#123;&#123;nodeId.property&#125;&#125;
-&#123;&#123;nodeId.nested.property&#125;&#125;
-&#123;&#123;nodeId.arrayField[0].name&#125;&#125;
+{{nodeId.property}}
+{{nodeId.nested.property}}
+{{nodeId.arrayField[0].name}}
 ```
 
 - `nodeId` — the ID of an upstream node (shown in the node config drawer)
@@ -21,15 +21,15 @@ Expressions let you pass data from one step to another without writing glue code
 
 Expressions can be used in any config field of type `string`, `expression`, or `textarea`. They are also used in Branch conditions and Loop collection fields.
 
-| Field type   | Expression support                                                                                  |
-| ------------ | --------------------------------------------------------------------------------------------------- |
-| `string`     | Yes — embedded in the value, e.g. `Hello <span v-pre>&#123;&#123;user_step.name&#125;&#125;</span>` |
-| `expression` | Yes — the entire value is an expression                                                             |
-| `textarea`   | Yes — embedded in multi-line text                                                                   |
-| `number`     | No — use a Step node to compute numeric values                                                      |
-| `select`     | No — options are fixed at design time                                                               |
-| `secret`     | No — secrets bind to env vars, not upstream outputs                                                 |
-| `code`       | Yes — reference upstream vars directly by name in JavaScript                                        |
+| Field type   | Expression support                                                            |
+| ------------ | ----------------------------------------------------------------------------- |
+| `string`     | Yes — embedded in the value, e.g. <code v-pre>Hello {{user_step.name}}</code> |
+| `expression` | Yes — the entire value is an expression                                       |
+| `textarea`   | Yes — embedded in multi-line text                                             |
+| `number`     | No — use a Step node to compute numeric values                                |
+| `select`     | No — options are fixed at design time                                         |
+| `secret`     | No — secrets bind to env vars, not upstream outputs                           |
+| `code`       | Yes — reference upstream vars directly by name in JavaScript                  |
 
 ## Examples
 
@@ -38,7 +38,7 @@ Expressions can be used in any config field of type `string`, `expression`, or `
 In a **Send Email** node's "To" field:
 
 ```
-&#123;&#123;create_user.email&#125;&#125;
+{{create_user.email}}
 ```
 
 This resolves to the `email` property of the `create_user` step's return value.
@@ -46,7 +46,7 @@ This resolves to the `email` property of the `create_user` step's return value.
 ### Nested property access
 
 ```
-&#123;&#123;parse_webhook.body.order.id&#125;&#125;
+{{parse_webhook.body.order.id}}
 ```
 
 ### Embedding in text
@@ -54,18 +54,18 @@ This resolves to the `email` property of the `create_user` step's return value.
 In a message body field:
 
 ```
-Hello &#123;&#123;user.firstName&#125;&#125;, your order &#123;&#123;place_order.orderId&#125;&#125; has been confirmed.
+Hello {{user.firstName}}, your order {{place_order.orderId}} has been confirmed.
 ```
 
 ## How expressions resolve
 
-At code-generation time, `<span v-pre>&#123;&#123;nodeId.property&#125;&#125;</span>` is replaced with a JavaScript property access on the step result variable:
+At code-generation time, <code v-pre>{{nodeId.property}}</code> is replaced with a JavaScript property access on the step result variable:
 
 ```typescript
-// &#123;&#123;create_user.email&#125;&#125; becomes:
+// {{create_user.email}} becomes:
 create_user.email
 
-// &#123;&#123;parse_webhook.body.order.id&#125;&#125; becomes:
+// {{parse_webhook.body.order.id}} becomes:
 parse_webhook.body.order.id
 ```
 
@@ -79,7 +79,7 @@ await step.do(`Send email to ${create_user.email}`, async () => {
 
 ## Autocomplete
 
-In config fields that support expressions, the UI provides autocomplete. After typing `&#123;&#123;`, a dropdown shows all upstream nodes and their typed output fields. Navigate with arrow keys and press Enter to insert.
+In config fields that support expressions, the UI provides autocomplete. After typing <code v-pre>{{</code>, a dropdown shows all upstream nodes and their typed output fields. Navigate with arrow keys and press Enter to insert.
 
 The autocomplete tree mirrors the `outputSchema` of each node definition.
 
@@ -109,4 +109,4 @@ return {
 }
 ```
 
-Then reference `<span v-pre>&#123;&#123;parse_trigger.orderId&#125;&#125;</span>` in downstream nodes.
+Then reference <code v-pre>{{parse_trigger.orderId}}</code> in downstream nodes.

--- a/apps/docs/building-workflows/sequential.md
+++ b/apps/docs/building-workflows/sequential.md
@@ -19,10 +19,10 @@ The workflow below has two steps:
 
 ### Canvas nodes
 
-| Order | Node name      | Node type          | Key config                                                            |
-| ----- | -------------- | ------------------ | --------------------------------------------------------------------- |
-| 1     | Validate Input | Step               | Custom TypeScript                                                     |
-| 2     | Send Email     | Resend: Send Email | to: `<span v-pre>&#123;&#123;validate_input.email&#125;&#125;</span>` |
+| Order | Node name      | Node type          | Key config                                      |
+| ----- | -------------- | ------------------ | ----------------------------------------------- |
+| 1     | Validate Input | Step               | Custom TypeScript                               |
+| 2     | Send Email     | Resend: Send Email | to: <code v-pre>{{validate_input.email}}</code> |
 
 ### Generated TypeScript
 

--- a/apps/docs/building-workflows/sleeping.md
+++ b/apps/docs/building-workflows/sleeping.md
@@ -37,7 +37,7 @@ The **Sleep Until** node pauses until a specific timestamp.
 The timestamp can be a static value or an expression referencing an upstream step output:
 
 ```
-&#123;&#123;parse_schedule.scheduledAt&#125;&#125;
+{{parse_schedule.scheduledAt}}
 ```
 
 ### Generated code

--- a/apps/docs/concepts/canvas.md
+++ b/apps/docs/concepts/canvas.md
@@ -26,26 +26,26 @@ Selecting a node opens the config panel in the right sidebar. The config panel r
 
 Each field type renders a different control:
 
-| Type          | Control                                                                                   |
-| ------------- | ----------------------------------------------------------------------------------------- |
-| `string`      | Single-line text input                                                                    |
-| `number`      | Numeric input with min/max validation                                                     |
-| `boolean`     | Toggle switch                                                                             |
-| `select`      | Dropdown with predefined options                                                          |
-| `multiselect` | Multi-select dropdown                                                                     |
-| `secret`      | Masked input that binds to an environment variable                                        |
-| `code`        | Monaco editor in TypeScript mode                                                          |
-| `json`        | Monaco editor in JSON mode                                                                |
-| `expression`  | Text input with `<span v-pre>&#123;&#123;nodeId.property&#125;&#125;</span>` autocomplete |
-| `textarea`    | Multi-line text area                                                                      |
+| Type          | Control                                                             |
+| ------------- | ------------------------------------------------------------------- |
+| `string`      | Single-line text input                                              |
+| `number`      | Numeric input with min/max validation                               |
+| `boolean`     | Toggle switch                                                       |
+| `select`      | Dropdown with predefined options                                    |
+| `multiselect` | Multi-select dropdown                                               |
+| `secret`      | Masked input that binds to an environment variable                  |
+| `code`        | Monaco editor in TypeScript mode                                    |
+| `json`        | Monaco editor in JSON mode                                          |
+| `expression`  | Text input with <code v-pre>{{nodeId.property}}</code> autocomplete |
+| `textarea`    | Multi-line text area                                                |
 
 ### Expression Autocomplete
 
-Fields of type `expression` provide autocomplete for the outputs of upstream nodes. Type `&#123;&#123;` to trigger the suggestion popup. Suggestions are drawn from the `outputSchema` of each upstream node.
+Fields of type `expression` provide autocomplete for the outputs of upstream nodes. Type <code v-pre>{{</code> to trigger the suggestion popup. Suggestions are drawn from the `outputSchema` of each upstream node.
 
 ```
-&#123;&#123;fetch_user.email&#125;&#125;
-&#123;&#123;charge_result.amount&#125;&#125;
+{{fetch_user.email}}
+{{charge_result.amount}}
 ```
 
 Only nodes that are topologically upstream of the current node appear in autocomplete. The editor shows an error indicator if an expression references a downstream node or a node that does not exist.

--- a/apps/docs/concepts/compilation.md
+++ b/apps/docs/concepts/compilation.md
@@ -25,7 +25,7 @@ Before any code is generated, the IR is passed through `validateIR` from `@await
 
 - **Schema validation** — all required fields present, all types correct (via Zod schemas)
 - **Graph validation** — entry node exists, all edges reference valid node IDs, no orphaned nodes
-- **Expression validation** — all `<span v-pre>&#123;&#123;nodeId.property&#125;&#125;</span>` expressions reference existing upstream nodes
+- **Expression validation** — all <code v-pre>{{nodeId.property}}</code> expressions reference existing upstream nodes
 - **Config validation** — required config fields are present for each node
 
 ```typescript
@@ -138,10 +138,10 @@ if (fetch_user_result.status === 200) {
 
 ### Expression Resolution
 
-During code generation, `<span v-pre>&#123;&#123;nodeId.property&#125;&#125;</span>` expressions in config values are resolved to direct JavaScript property accesses:
+During code generation, <code v-pre>{{nodeId.property}}</code> expressions in config values are resolved to direct JavaScript property accesses:
 
 ```typescript
-// Config value: "&#123;&#123;fetch_user_result.body&#125;&#125;"
+// Config value: "{{fetch_user_result.body}}"
 // Resolved to:  fetch_user_result.body
 ```
 

--- a/apps/docs/concepts/workflow-ir.md
+++ b/apps/docs/concepts/workflow-ir.md
@@ -145,12 +145,12 @@ In script mode, `sub_workflow` is always fire-and-forget — there is no durable
 
 ## Expression System
 
-Nodes can reference the output of upstream nodes using the `<span v-pre>&#123;&#123;nodeId.property&#125;&#125;</span>` expression syntax. Expressions are valid in any `expression`-typed config field and are resolved by the codegen pipeline at build time.
+Nodes can reference the output of upstream nodes using the <code v-pre>{{nodeId.property}}</code> expression syntax. Expressions are valid in any `expression`-typed config field and are resolved by the codegen pipeline at build time.
 
 ### Syntax
 
 ```
-&#123;&#123;nodeId.property.nestedProperty&#125;&#125;
+{{nodeId.property.nestedProperty}}
 ```
 
 - `nodeId` — the `id` of an upstream `WorkflowNode`
@@ -160,18 +160,18 @@ Nodes can reference the output of upstream nodes using the `<span v-pre>&#123;&#
 ### Examples
 
 ```
-&#123;&#123;fetch_user.email&#125;&#125;
-&#123;&#123;charge_result.amount&#125;&#125;
-&#123;&#123;get_orders.results.0.id&#125;&#125;
+{{fetch_user.email}}
+{{charge_result.amount}}
+{{get_orders.results.0.id}}
 ```
 
 ### How Expressions Are Resolved
 
-The codegen pipeline performs a topological sort of the DAG and assigns each node a JavaScript variable name. At code generation time, `<span v-pre>&#123;&#123;nodeId.property&#125;&#125;</span>` becomes a direct JavaScript property access:
+The codegen pipeline performs a topological sort of the DAG and assigns each node a JavaScript variable name. At code generation time, <code v-pre>{{nodeId.property}}</code> becomes a direct JavaScript property access:
 
 ```typescript
 // Before resolution (in IR data field):
-"to": "&#123;&#123;fetch_user.email&#125;&#125;"
+"to": "{{fetch_user.email}}"
 
 // After resolution (in generated worker code):
 const sendEmail_result = await step.do('sendEmail', async () => {
@@ -209,7 +209,7 @@ The IR validator checks that:
       "provider": "cloudflare",
       "data": {
         "method": "GET",
-        "url": "https://api.example.com/users/&#123;&#123;trigger.userId&#125;&#125;"
+        "url": "https://api.example.com/users/{{trigger.userId}}"
       }
     },
     {
@@ -220,7 +220,7 @@ The IR validator checks that:
       "version": "1.0.0",
       "provider": "cloudflare",
       "data": {
-        "to": "&#123;&#123;fetch_user.body&#125;&#125;",
+        "to": "{{fetch_user.body}}",
         "subject": "Welcome!"
       }
     }

--- a/apps/docs/contributing/project-structure.md
+++ b/apps/docs/contributing/project-structure.md
@@ -55,14 +55,14 @@ The React SPA. Key directories:
 
 The IR package defines the Workflow IR types and all logic that operates on them:
 
-| File                     | Purpose                                                                                   |
-| ------------------------ | ----------------------------------------------------------------------------------------- |
-| `src/types.ts`           | `WorkflowIR`, `WorkflowNode`, `Edge`, `TriggerConfig` types                               |
-| `src/schema.ts`          | Zod validation schema                                                                     |
-| `src/validate.ts`        | Semantic validation (cycle detection, expression checks)                                  |
-| `src/expressions.ts`     | Expression parser and resolver (`<span v-pre>&#123;&#123;nodeId.path&#125;&#125;</span>`) |
-| `src/node-definition.ts` | `NodeDefinition`, `ConfigField`, `OutputField` types                                      |
-| `src/bundled-nodes/`     | Built-in node definitions (http_request, etc.)                                            |
+| File                     | Purpose                                                             |
+| ------------------------ | ------------------------------------------------------------------- |
+| `src/types.ts`           | `WorkflowIR`, `WorkflowNode`, `Edge`, `TriggerConfig` types         |
+| `src/schema.ts`          | Zod validation schema                                               |
+| `src/validate.ts`        | Semantic validation (cycle detection, expression checks)            |
+| `src/expressions.ts`     | Expression parser and resolver (<code v-pre>{{nodeId.path}}</code>) |
+| `src/node-definition.ts` | `NodeDefinition`, `ConfigField`, `OutputField` types                |
+| `src/bundled-nodes/`     | Built-in node definitions (http_request, etc.)                      |
 
 ## packages/codegen
 

--- a/apps/docs/nodes/custom-nodes.md
+++ b/apps/docs/nodes/custom-nodes.md
@@ -68,7 +68,7 @@ nodes/
       "type": "expression",
       "label": "Customer ID",
       "required": true,
-      "placeholder": "&#123;&#123;fetch_customer.id&#125;&#125;"
+      "placeholder": "{{fetch_customer.id}}"
     },
     "apiKey": {
       "type": "secret",
@@ -183,7 +183,7 @@ export default async function (ctx: NodeContext<Config>): Promise<Output> {
 
 ## Output Schema
 
-The `outputSchema` types the node's return value. Downstream nodes can reference fields via `<span v-pre>&#123;&#123;nodeId.fieldName&#125;&#125;</span>`.
+The `outputSchema` types the node's return value. Downstream nodes can reference fields via <code v-pre>{{nodeId.fieldName}}</code>.
 
 ```json
 {

--- a/apps/docs/nodes/overview.md
+++ b/apps/docs/nodes/overview.md
@@ -4,7 +4,7 @@ A node is a reusable, self-describing workflow building block. Every node on the
 
 - **What it does** — a name, description, and category
 - **What it needs** — a config schema that drives the UI form automatically
-- **What it produces** — a typed output schema that downstream nodes can reference via `<span v-pre>&#123;&#123;nodeId.property&#125;&#125;</span>`
+- **What it produces** — a typed output schema that downstream nodes can reference via <code v-pre>{{nodeId.property}}</code>
 - **How it runs** — one or more code templates, one per execution provider
 
 Every node is automatically wrapped in `step.do()` by the compile pipeline. You never write retry or durability logic — the platform handles it.

--- a/apps/docs/troubleshooting/deploy-failures.md
+++ b/apps/docs/troubleshooting/deploy-failures.md
@@ -60,7 +60,7 @@ See [Wrangler Errors](./wrangler-errors.md) for more wrangler-specific issues.
 
 **Fix:** The deploy response includes a list of validation errors with node IDs and paths. Open the canvas and address each error:
 
-- Fix broken expression references (`<span v-pre>&#123;&#123;unknownNode.field&#125;&#125;</span>` pointing to a removed node).
+- Fix broken expression references (<code v-pre>{{unknownNode.field}}</code> pointing to a removed node).
 - Connect all nodes — every node must be reachable from the entry node.
 - Check that `select` fields have a valid option selected.
 

--- a/apps/docs/troubleshooting/wrangler-errors.md
+++ b/apps/docs/troubleshooting/wrangler-errors.md
@@ -107,7 +107,7 @@ Worker names are derived from the workflow name and the `APP_NAME` env var.
 
 1. Click **View Generated Code** in the workflow toolbar (or fetch the version via API).
 2. Review the generated TypeScript for obvious errors.
-3. Check that all `<span v-pre>&#123;&#123;expression&#125;&#125;</span>` references resolve to the correct values.
+3. Check that all <code v-pre>{{expression}}</code> references resolve to the correct values.
 4. Add console.log statements to Step nodes to debug (visible in Cloudflare Worker logs). Remove them before the final deploy.
 
 ---

--- a/apps/web/src/components/dashboard/import-workflow-dialog.tsx
+++ b/apps/web/src/components/dashboard/import-workflow-dialog.tsx
@@ -3,8 +3,8 @@ import { useNavigate } from '@tanstack/react-router'
 import { useMutation, useQueryClient } from '@tanstack/react-query'
 import { Upload, FileText, AlertCircle, Loader2 } from 'lucide-react'
 import * as Dialog from '@radix-ui/react-dialog'
-import { validateIR } from '@awaitstep/ir'
-import type { WorkflowIR } from '@awaitstep/ir'
+import { validateArtifact } from '@awaitstep/ir'
+import type { ArtifactIR } from '@awaitstep/ir'
 import { Button } from '../ui/button'
 import { CodeEditor } from '../ui/code-editor'
 import { api } from '../../lib/api-client'
@@ -14,7 +14,7 @@ type InputMode = 'paste' | 'file'
 
 function parseAndValidate(
   raw: string,
-): { ir: WorkflowIR; errors: null } | { ir: null; errors: string[] } {
+): { ir: ArtifactIR; errors: null } | { ir: null; errors: string[] } {
   let parsed: unknown
   try {
     parsed = JSON.parse(raw)
@@ -22,7 +22,7 @@ function parseAndValidate(
     return { ir: null, errors: ['Invalid JSON — check for syntax errors.'] }
   }
 
-  const result = validateIR(parsed)
+  const result = validateArtifact(parsed)
   if (!result.ok) {
     return {
       ir: null,
@@ -41,7 +41,7 @@ export function ImportWorkflowDialog({ onClose }: { onClose: () => void }) {
   const [jsonText, setJsonText] = useState('')
   const [fileName, setFileName] = useState<string | null>(null)
   const [name, setName] = useState('')
-  const [validIR, setValidIR] = useState<WorkflowIR | null>(null)
+  const [validIR, setValidIR] = useState<ArtifactIR | null>(null)
   const [errors, setErrors] = useState<string[]>([])
   const [isDragOver, setIsDragOver] = useState(false)
   const fileInputRef = useRef<HTMLInputElement>(null)
@@ -121,22 +121,24 @@ export function ImportWorkflowDialog({ onClose }: { onClose: () => void }) {
       const workflow = await api.createWorkflow({
         name: name.trim() || validIR.metadata.name,
         description: validIR.metadata.description,
+        kind: validIR.kind,
       })
       await api.createVersion(workflow.id, { ir: validIR })
       return workflow
     },
     onSuccess: (workflow) => {
+      const isScript = validIR?.kind === 'script'
       queryClient.invalidateQueries({ queryKey: ['workflows'] })
       navigate({
         to: '/workflows/$workflowId/canvas',
         params: { workflowId: workflow.id },
       }).finally(() => {
-        toast.success('Workflow imported')
+        toast.success(isScript ? 'Function imported' : 'Workflow imported')
         onClose()
       })
     },
     onError: (err) => {
-      toast.error(err instanceof Error ? err.message : 'Failed to import workflow')
+      toast.error(err instanceof Error ? err.message : 'Failed to import')
     },
   })
 
@@ -154,10 +156,12 @@ export function ImportWorkflowDialog({ onClose }: { onClose: () => void }) {
           onDragLeave={() => setIsDragOver(false)}
         >
           <Dialog.Title className="text-base font-semibold text-foreground">
-            Import Workflow
+            Import Workflow or Function
           </Dialog.Title>
           <p className="mt-1 text-xs text-muted-foreground">
-            Paste an IR JSON document or upload an exported <code>.ir.json</code> file.
+            Paste an IR JSON document or upload an exported <code>.ir.json</code> file. The kind (
+            <code>workflow</code> or <code>script</code>) is read from the IR's <code>kind</code>{' '}
+            field; absent <code>kind</code> imports as a workflow.
           </p>
 
           {/* Mode tabs */}
@@ -259,17 +263,28 @@ export function ImportWorkflowDialog({ onClose }: { onClose: () => void }) {
             </div>
           )}
 
-          {/* Workflow name (shown when IR is valid) */}
+          {/* Name + detected kind (shown when IR is valid) */}
           {validIR && (
             <div className="mt-3">
-              <label className="text-xs font-medium text-foreground/60">Workflow name</label>
+              <label className="text-xs font-medium text-foreground/60">
+                {validIR.kind === 'script' ? 'Function name' : 'Workflow name'}
+              </label>
               <input
                 type="text"
                 value={name}
                 onChange={(e) => setName(e.target.value)}
                 className="mt-1 w-full rounded-md border border-border bg-muted/30 px-3 py-2 text-sm text-foreground outline-none focus:border-primary/40"
               />
-              <p className="mt-1.5 text-xs text-muted-foreground">
+              <p className="mt-1.5 flex items-center gap-2 text-xs text-muted-foreground">
+                <span
+                  className={`rounded px-1.5 py-0.5 text-[10px] font-medium uppercase tracking-wide ${
+                    validIR.kind === 'script'
+                      ? 'bg-violet-500/15 text-violet-600 dark:text-violet-300'
+                      : 'bg-emerald-500/15 text-emerald-600 dark:text-emerald-300'
+                  }`}
+                >
+                  {validIR.kind === 'script' ? 'Function' : 'Workflow'}
+                </span>
                 {validIR.nodes.length} nodes, {validIR.edges.length} edges
               </p>
             </div>

--- a/apps/web/src/components/dashboard/new-artifact-dropdown.tsx
+++ b/apps/web/src/components/dashboard/new-artifact-dropdown.tsx
@@ -1,0 +1,68 @@
+import { useNavigate } from '@tanstack/react-router'
+import { ChevronDown, Plus, Workflow, Zap } from 'lucide-react'
+import { Button } from '../ui/button'
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from '../ui/dropdown-menu'
+import { useSheetStore } from '../../stores/sheet-store'
+import { NEW_FUNCTION_NAV, NEW_WORKFLOW_NAV } from '../../lib/nav'
+
+interface NewArtifactDropdownProps {
+  size?: 'sm' | 'default'
+}
+
+/**
+ * The "New" button shared between the workflows index page and the dashboard
+ * workflow list. Surfaces both artifact kinds (Workflow + Function) so users
+ * can discover Function creation from either entry point.
+ */
+export function NewArtifactDropdown({ size = 'sm' }: NewArtifactDropdownProps) {
+  const navigate = useNavigate()
+  const { guardAction } = useSheetStore()
+
+  const goNew = (target: 'workflow' | 'function') => {
+    guardAction('project', () =>
+      navigate(target === 'function' ? NEW_FUNCTION_NAV : NEW_WORKFLOW_NAV),
+    )
+  }
+
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger asChild>
+        <Button size={size} className="gap-1.5">
+          <Plus className="h-4 w-4" />
+          New
+          <ChevronDown className="h-4 w-4 opacity-70" />
+        </Button>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent align="end" className="w-72">
+        <DropdownMenuItem onSelect={() => goNew('workflow')}>
+          <Workflow className="h-4 w-4" />
+          <div className="flex flex-col">
+            <span>Workflow</span>
+            <span className="text-xs text-muted-foreground">
+              Durable, multi-step, with sleeps and waits
+            </span>
+          </div>
+        </DropdownMenuItem>
+        <DropdownMenuItem onSelect={() => goNew('function')}>
+          <Zap className="h-4 w-4" />
+          <div className="flex flex-col">
+            <span className="flex items-center gap-1.5">
+              Function
+              <span className="rounded bg-primary/10 px-1 py-0.5 text-[9px] font-semibold uppercase tracking-wide text-primary">
+                Beta
+              </span>
+            </span>
+            <span className="text-xs text-muted-foreground">
+              Stateless, runs synchronously, returns immediately
+            </span>
+          </div>
+        </DropdownMenuItem>
+      </DropdownMenuContent>
+    </DropdownMenu>
+  )
+}

--- a/apps/web/src/components/dashboard/workflow-actions-menu.tsx
+++ b/apps/web/src/components/dashboard/workflow-actions-menu.tsx
@@ -61,6 +61,7 @@ export function WorkflowActionsMenu({ workflow, isDeployed }: WorkflowActionsMen
       const newWf = await api.createWorkflow({
         name: `${workflow.name} (copy)`,
         description: workflow.description,
+        kind: workflow.kind,
       })
       if (workflow.currentVersionId) {
         const ver = await api.getVersion(workflow.id, workflow.currentVersionId)

--- a/apps/web/src/components/dashboard/workflow-list.tsx
+++ b/apps/web/src/components/dashboard/workflow-list.tsx
@@ -1,5 +1,5 @@
 import { Link } from '@tanstack/react-router'
-import { Plus } from 'lucide-react'
+import { Plus, Workflow } from 'lucide-react'
 import { Button, buttonVariants } from '../ui/button'
 import { GuardedLink } from '../ui/guarded-link'
 import type { WorkflowSummary } from '../../lib/api-client'
@@ -7,12 +7,12 @@ import { useWorkflowsStore } from '../../stores/workflows-store'
 import { WorkflowStatusBadge } from './workflow-status-badge'
 import { WorkflowActionsMenu } from './workflow-actions-menu'
 import { TriggerButton } from './trigger-button'
+import { NewArtifactDropdown } from './new-artifact-dropdown'
 import { timeAgo } from '../../lib/time'
 import { NEW_WORKFLOW_NAV } from '../../lib/nav'
 import { useShallow } from 'zustand/react/shallow'
 import { LoadingView } from '../ui/loading-view'
 import { EmptyState } from '../ui/empty-state'
-import { Workflow } from 'lucide-react'
 
 export function WorkflowList() {
   const { workflows, isLoading, hasMore } = useWorkflowsStore(
@@ -37,14 +37,7 @@ export function WorkflowList() {
               </Button>
             </Link>
           )}
-          <GuardedLink
-            className={buttonVariants({ size: 'sm' })}
-            requirement="project"
-            nav={NEW_WORKFLOW_NAV}
-          >
-            <Plus className="h-4 w-4" />
-            New Workflow
-          </GuardedLink>
+          <NewArtifactDropdown />
         </div>
       </div>
 

--- a/apps/web/src/routes/_authed/workflows.index.tsx
+++ b/apps/web/src/routes/_authed/workflows.index.tsx
@@ -1,24 +1,18 @@
-import { createFileRoute, Link, useNavigate } from '@tanstack/react-router'
-import { ChevronDown, Plus, Search, Upload, Workflow, Zap } from 'lucide-react'
+import { createFileRoute, Link } from '@tanstack/react-router'
+import { Plus, Search, Upload, Workflow } from 'lucide-react'
 import { useState, useMemo } from 'react'
 import { Button } from '../../components/ui/button'
 import { GuardedLink } from '../../components/ui/guarded-link'
-import {
-  DropdownMenu,
-  DropdownMenuContent,
-  DropdownMenuItem,
-  DropdownMenuTrigger,
-} from '../../components/ui/dropdown-menu'
 import { PageHeader } from '../../components/ui/page-header'
 import type { WorkflowSummary } from '../../lib/api-client'
 import { useWorkflowsStore } from '../../stores/workflows-store'
-import { useSheetStore } from '../../stores/sheet-store'
 import { WorkflowActionsMenu } from '../../components/dashboard/workflow-actions-menu'
 import { TriggerButton } from '../../components/dashboard/trigger-button'
 import { ImportWorkflowDialog } from '../../components/dashboard/import-workflow-dialog'
+import { NewArtifactDropdown } from '../../components/dashboard/new-artifact-dropdown'
 import { timeAgo } from '../../lib/time'
 import { RequireProject } from '../../wrappers/require-project'
-import { NEW_FUNCTION_NAV, NEW_WORKFLOW_NAV } from '../../lib/nav'
+import { NEW_WORKFLOW_NAV } from '../../lib/nav'
 import { LoadingView } from '../../components/ui/loading-view'
 import { LoadMoreButton } from '../../components/ui/load-more-button'
 import { ListSkeleton } from '../../components/ui/skeletons'
@@ -38,8 +32,6 @@ function WorkflowsIndexPage() {
 }
 
 function WorkflowsIndexContent() {
-  const navigate = useNavigate()
-  const { guardAction } = useSheetStore()
   const workflows = useWorkflowsStore((s) => s.workflows)
   const isLoading = useWorkflowsStore((s) => s.fetchState === 'idle' || s.fetchState === 'loading')
   const hasMore = useWorkflowsStore((s) => s.hasMore)
@@ -47,12 +39,6 @@ function WorkflowsIndexContent() {
   const isFetchingMore = useWorkflowsStore((s) => s.isFetchingMore)
   const [search, setSearch] = useState('')
   const [importOpen, setImportOpen] = useState(false)
-
-  const goNew = (target: 'workflow' | 'function') => {
-    guardAction('project', () =>
-      navigate(target === 'function' ? NEW_FUNCTION_NAV : NEW_WORKFLOW_NAV),
-    )
-  }
 
   const filtered = useMemo(() => {
     if (!search.trim()) return workflows
@@ -78,40 +64,7 @@ function WorkflowsIndexContent() {
               <Upload className="h-4 w-4" />
               Import
             </Button>
-            <DropdownMenu>
-              <DropdownMenuTrigger asChild>
-                <Button size="sm" className="gap-1.5">
-                  <Plus className="h-4 w-4" />
-                  New
-                  <ChevronDown className="h-4 w-4 opacity-70" />
-                </Button>
-              </DropdownMenuTrigger>
-              <DropdownMenuContent align="end" className="w-72">
-                <DropdownMenuItem onSelect={() => goNew('workflow')}>
-                  <Workflow className="h-4 w-4" />
-                  <div className="flex flex-col">
-                    <span>Workflow</span>
-                    <span className="text-xs text-muted-foreground">
-                      Durable, multi-step, with sleeps and waits
-                    </span>
-                  </div>
-                </DropdownMenuItem>
-                <DropdownMenuItem onSelect={() => goNew('function')}>
-                  <Zap className="h-4 w-4" />
-                  <div className="flex flex-col">
-                    <span className="flex items-center gap-1.5">
-                      Function
-                      <span className="rounded bg-primary/10 px-1 py-0.5 text-[9px] font-semibold uppercase tracking-wide text-primary">
-                        Beta
-                      </span>
-                    </span>
-                    <span className="text-xs text-muted-foreground">
-                      Stateless, runs synchronously, returns immediately
-                    </span>
-                  </div>
-                </DropdownMenuItem>
-              </DropdownMenuContent>
-            </DropdownMenu>
+            <NewArtifactDropdown />
           </div>
         }
       />


### PR DESCRIPTION
## Summary

Promotes two follow-up fixes from `dev` to `main`:

- **#161 — scripts primitive UX gaps.** Real-world testing surfaced two paths that hadn't been wired for `kind: "script"`. The Import dialog called `validateIR` (workflow-only) so any pasted script IR failed schema validation; same path also dropped `kind` on `api.createWorkflow`, which would have silently demoted scripts to workflows on round-trip. Duplicate from the workflow actions menu had the same kind-drop bug. Plus the dashboard's "New Workflow" button bypassed Function creation entirely — now both surfaces use a shared `NewArtifactDropdown`.
- **#162 — public docs expression rendering.** `{{ }}` expressions were rendering as literal `&#123;` entity text in the public site. Two layered bugs (entity escaping inside fenced code; `<span v-pre>` wrapped in inline backticks defeating v-pre). Fix: literal `{{ }}` inside fences (VitePress' v-pre semantics handle it) and `<code v-pre>{{x}}</code>` in prose. `vitepress build` now passes.

5 commits ahead of `main`. release-please should compute a patch bump from the `fix:` prefixes.

## Test plan

- [ ] CI green on `dev` HEAD (`pnpm test` / `build` / `lint` / `type-check`)
- [ ] Smoke #161: Import the user-reported `kind: "script"` IR → "Function imported" → canvas opens with Function badge
- [ ] Smoke #161: Duplicate a deployed Function → new row's kind matches; canvas badge correct
- [ ] Smoke #161: From `/dashboard`, the "New" dropdown surfaces Workflow + Function (Beta)
- [ ] Smoke #162: Browse the rendered docs site and confirm `{{ }}` shows correctly in:
  - Workflow & Script IR → Examples
  - Canvas → Expression Autocomplete
  - Building Workflows → Expressions
  - API → IR Schema, Webhooks
- [ ] Back-compat: existing workflows with no `kind` field continue to load and deploy