### PR TITLE
fix: script-mode codegen cleanup (validator + IIFE removal + loop counter)

### DIFF
--- a/packages/ir/src/__tests__/expressions.test.ts
+++ b/packages/ir/src/__tests__/expressions.test.ts
@@ -138,4 +138,38 @@ describe('validateExpressionRefs', () => {
     const errors = validateExpressionRefs('plain text', 'step1', new Set(), allNodes)
     expect(errors).toEqual([])
   })
+
+  describe('reserved refs', () => {
+    it('passes {{event.payload.X}} without an "event" node', () => {
+      const upstream = new Set<string>()
+      const errors = validateExpressionRefs(
+        '{{event.payload.recipients}}',
+        'step1',
+        upstream,
+        allNodes,
+      )
+      expect(errors).toEqual([])
+    })
+
+    it('passes {{env.MY_VAR}} without an "env" node', () => {
+      const errors = validateExpressionRefs('{{env.RESEND_API_KEY}}', 'step1', new Set(), allNodes)
+      expect(errors).toEqual([])
+    })
+
+    it('passes {{trigger.userId}} without a "trigger" node', () => {
+      const errors = validateExpressionRefs('{{trigger.userId}}', 'step1', new Set(), allNodes)
+      expect(errors).toEqual([])
+    })
+
+    it('still flags genuine bad refs alongside reserved ones', () => {
+      const errors = validateExpressionRefs(
+        '{{event.payload.x}} + {{missing.y}}',
+        'step1',
+        new Set(),
+        allNodes,
+      )
+      expect(errors).toHaveLength(1)
+      expect(errors[0]!.nodeId).toBe('missing')
+    })
+  })
 })

--- a/packages/ir/src/expressions.ts
+++ b/packages/ir/src/expressions.ts
@@ -7,6 +7,18 @@
 
 const EXPRESSION_PATTERN = /\{\{(\w+(?:\.\w+)*)\}\}/g
 
+/**
+ * Identifiers that are runtime-provided (not node IDs) and should bypass
+ * the upstream/exists checks in {@link validateExpressionRefs}:
+ *
+ * - `event` — the parameter to `WorkflowEntrypoint.run(event, step)` (workflow)
+ *   and `runGraph(env, event)` (script). Used as `{{event.payload.X}}`.
+ * - `env`   — the environment binding object. Used as `{{env.MY_VAR}}`; the
+ *   codegen has dedicated env-var scanning for this prefix.
+ * - `trigger` — alias used in some docs/examples for the trigger payload.
+ */
+export const RESERVED_EXPRESSION_REFS = new Set(['event', 'env', 'trigger'])
+
 export interface ParsedExpression {
   raw: string
   nodeId: string
@@ -77,6 +89,7 @@ export function validateExpressionRefs(
   const expressions = parseExpressions(input)
 
   for (const expr of expressions) {
+    if (RESERVED_EXPRESSION_REFS.has(expr.nodeId)) continue
     if (expr.nodeId === currentNodeId) {
       errors.push({
         expression: expr.raw,

--- a/packages/ir/src/index.ts
+++ b/packages/ir/src/index.ts
@@ -65,6 +65,7 @@ export {
   parseExpressions,
   resolveExpressions,
   validateExpressionRefs,
+  RESERVED_EXPRESSION_REFS,
   type ParsedExpression,
   type ExpressionValidationError,
 } from './expressions.js'

--- a/packages/provider-cloudflare/src/__tests__/codegen/generate-script.test.ts
+++ b/packages/provider-cloudflare/src/__tests__/codegen/generate-script.test.ts
@@ -240,6 +240,152 @@ describe('generateScript', () => {
     expect(code).toContain('if (request.method !== "POST")')
   })
 
+  it('emits a forEach loop without IIFE or _loop_i when body has no step.METHOD', () => {
+    const ir = makeScript([
+      {
+        id: 'send',
+        type: 'loop',
+        name: 'Send mail to recipients',
+        position: { x: 0, y: 0 },
+        version: '1.0.0',
+        provider: 'cloudflare',
+        data: {
+          loopType: 'forEach',
+          collection: 'event.payload.recipients',
+          itemVar: 'email',
+        },
+      },
+      stepNode('inner', 'await env.SEND_MAIL.create({ id: crypto.randomUUID(), email });'),
+    ])
+    ir.edges = [{ id: 'e1', source: 'send', target: 'inner', label: 'body' }]
+    const code = generateScript(ir)
+
+    // No IIFE wrap — the body doesn't capture _output, so no need.
+    expect(code).not.toContain('await (async () => {')
+    // No dead step-name counter in script mode — script bodies have no step.do.
+    expect(code).not.toContain('let _loop_i = 0')
+    expect(code).not.toContain('_loop_i++')
+    // Bare for-of with the user's iteration variable.
+    expect(code).toContain('for (const email of event.payload.recipients) {')
+  })
+
+  it('keeps the IIFE for a script-mode loop that captures _output', () => {
+    const ir = makeScript([
+      {
+        id: 'find',
+        type: 'loop',
+        name: 'EXPORT_FirstMatch',
+        position: { x: 0, y: 0 },
+        version: '1.0.0',
+        provider: 'cloudflare',
+        data: { loopType: 'forEach', collection: 'event.payload.items', itemVar: 'item' },
+      },
+      stepNode('check', 'if (item.match) _output = item;'),
+    ])
+    ir.edges = [{ id: 'e1', source: 'find', target: 'check', label: 'body' }]
+    const code = generateScript(ir)
+
+    // Body assigns to _output, so we keep the IIFE to capture it as a const.
+    // Uses EXPORT_ prefix so post-processing retains the const declaration.
+    expect(code).toMatch(
+      /const FirstMatch = await \(async \(\) => \{[\s\S]*let _output;[\s\S]*return _output;\s*\}\)\(\);/,
+    )
+  })
+
+  it('script-mode times loop keeps the _loop_i iterator (it IS the loop counter)', () => {
+    const ir = makeScript([
+      {
+        id: 'tries',
+        type: 'loop',
+        name: 'Tries',
+        position: { x: 0, y: 0 },
+        version: '1.0.0',
+        provider: 'cloudflare',
+        data: { loopType: 'times', count: 3 },
+      },
+      stepNode('work', 'console.log(_loop_i);'),
+    ])
+    ir.edges = [{ id: 'e1', source: 'tries', target: 'work', label: 'body' }]
+    const code = generateScript(ir)
+
+    expect(code).toContain('for (let _loop_i = 0; _loop_i < 3; _loop_i++)')
+    // No outer IIFE since body doesn't capture _output.
+    expect(code).not.toContain('await (async () => {')
+  })
+
+  it('flattens http_request in script mode (no IIFE) — simple GET case', () => {
+    // EXPORT_-prefix the node so EXPORT_ post-processing keeps the `const X = ...`
+    // assignment instead of stripping it as unused.
+    const ir = makeScript([
+      {
+        id: 'fetch_user',
+        type: 'http_request',
+        name: 'EXPORT_FetchUser',
+        position: { x: 0, y: 0 },
+        version: '1.0.0',
+        provider: 'cloudflare',
+        data: { method: 'GET', url: 'https://api.example.com/users/1' },
+      },
+    ])
+    const code = generateScript(ir)
+    expect(code).not.toContain('await (async () => {')
+    expect(code).toMatch(
+      /const FetchUser = await fetch\("https:\/\/api\.example\.com\/users\/1"\)\.then\(r => r\.json\(\)\);/,
+    )
+  })
+
+  it('flattens http_request with queryParams using namespaced url builder', () => {
+    const ir = makeScript([
+      {
+        id: 'search',
+        type: 'http_request',
+        name: 'EXPORT_Search',
+        position: { x: 0, y: 0 },
+        version: '1.0.0',
+        provider: 'cloudflare',
+        data: {
+          method: 'GET',
+          url: 'https://api.example.com/search',
+          queryParams: { q: 'hello', limit: '10' },
+        },
+      },
+    ])
+    const code = generateScript(ir)
+    expect(code).not.toContain('await (async () => {')
+    // Intermediate var is namespaced by node varName so siblings don't collide.
+    expect(code).toContain('const _Search_url = new URL("https://api.example.com/search")')
+    expect(code).toContain('_Search_url.searchParams.set("q", "hello")')
+    // Final assignment keeps `const ${varName}` so EXPORT_ post-processing finds it.
+    expect(code).toMatch(/const Search = await fetch\(_Search_url\)\.then\(r => r\.json\(\)\);/)
+  })
+
+  it('emits parallel/race in script mode without an outer IIFE wrap', () => {
+    const ir = makeScript([
+      {
+        id: 'fan',
+        type: 'parallel',
+        name: 'EXPORT_Fan',
+        position: { x: 0, y: 0 },
+        version: '1.0.0',
+        provider: 'cloudflare',
+        data: {},
+      },
+      stepNode('a', 'return 1;'),
+      stepNode('b', 'return 2;'),
+    ])
+    ir.edges = [
+      { id: 'e1', source: 'fan', target: 'a' },
+      { id: 'e2', source: 'fan', target: 'b' },
+    ]
+    const code = generateScript(ir)
+
+    // No `step.do`, no outer IIFE — Promise.allSettled is awaited directly.
+    expect(code).not.toContain('step.do')
+    expect(code).not.toMatch(/await \(async \(\) => \{\s*return await Promise\./)
+    // The Promise.allSettled call is the bare expression assigned to the var.
+    expect(code).toMatch(/const Fan = await Promise\.allSettled\(\[/)
+  })
+
   it('integrates a custom node template (hoists class, IIFE call, env param)', () => {
     const template = `export default async function(ctx) {
   return { url: ctx.config.url, key: ctx.env.API_KEY };

--- a/packages/provider-cloudflare/src/__tests__/codegen/generators/loop.test.ts
+++ b/packages/provider-cloudflare/src/__tests__/codegen/generators/loop.test.ts
@@ -52,15 +52,39 @@ describe('generateLoop', () => {
     expect(code).toContain('for (let _loop_i')
   })
 
-  it('generates forEach loop', () => {
+  it('generates forEach loop using .entries() when body has step.do calls (counter inline)', () => {
     const ir = makeLoopIR(
       { loopType: 'forEach', collection: 'get_customers.customers', itemVar: 'customer' },
       [step('send', 'Send Email')],
     )
     const code = generateLoop(ir.nodes[0]!, ir, generateNodeCode)
-    expect(code).toContain('for (const customer of get_customers.customers)')
+    // Counter comes from .entries() destructure — no separate `let _loop_i = 0` declaration.
+    expect(code).toContain('for (const [_loop_i, customer] of (get_customers.customers).entries())')
     expect(code).toContain('Send Email [${_loop_i}]')
-    expect(code).toContain('let _loop_i = 0')
+    expect(code).not.toContain('let _loop_i = 0')
+  })
+
+  it('generates forEach without counter when body has no step.METHOD calls', () => {
+    const noStepBody: WorkflowNode = {
+      id: 'inline',
+      type: 'step',
+      name: 'Inline',
+      position: { x: 0, y: 0 },
+      version: V,
+      provider: P,
+      data: { code: 'console.log(item);' }, // no step.do/sleep/etc inside the inline code
+    }
+    // Use a custom-node-style call to avoid step.do — but step nodes always
+    // use step.do in workflow mode. So this assertion is mainly relevant in
+    // script mode (covered separately). Keep this one minimal — confirm
+    // `_loop_i` isn't redundantly declared when entries() does it.
+    const ir = makeLoopIR({ loopType: 'forEach', collection: 'items', itemVar: 'item' }, [
+      noStepBody,
+    ])
+    const code = generateLoop(ir.nodes[0]!, ir, generateNodeCode)
+    // step nodes wrap with step.do, so counter IS needed → entries() form.
+    expect(code).toContain('for (const [_loop_i, item] of (items).entries())')
+    expect(code).not.toContain('let _loop_i = 0')
   })
 
   it('generates while loop without condition (while true)', () => {

--- a/packages/provider-cloudflare/src/codegen/generators/container-utils.ts
+++ b/packages/provider-cloudflare/src/codegen/generators/container-utils.ts
@@ -89,11 +89,9 @@ export function generatePromiseContainer(
     .filter(Boolean)
 
   if (mode === 'script') {
-    return `const ${varName(node.id)} = await (async () => {
-  return await Promise.${method}([
+    return `const ${varName(node.id)} = await Promise.${method}([
 ${branches.join(',\n')}
-  ].map(fn => fn()));
-})();`
+].map(fn => fn()));`
   }
   return `const ${varName(node.id)} = await step.do("${escName(node.name)}", async () => {
   return await Promise.${method}([

--- a/packages/provider-cloudflare/src/codegen/generators/http.ts
+++ b/packages/provider-cloudflare/src/codegen/generators/http.ts
@@ -56,9 +56,24 @@ export function generateHttp(node: WorkflowNode, mode: GenerateMode = 'workflow'
   const bodyCode = lines.map((l) => `  ${l}`).join('\n')
 
   if (mode === 'script') {
-    return `const ${varName(node.id)} = await (async () => {
-${bodyCode}
-})();`
+    // No `step.do` boundary in script mode, so emit the body inline. The
+    // simple no-queryparams case collapses to a single expression. With
+    // queryparams the URL builder needs intermediate vars — namespace them
+    // by node id so siblings don't collide, and keep the final assignment
+    // as `const ${varName(node.id)} = ...` so the EXPORT_ post-processing
+    // (which scans for `const X =`) still finds it.
+    if (!hasQueryParams) {
+      const urlLiteral = toJsLiteral(url)
+      return `const ${varName(node.id)} = await fetch(${urlLiteral}${fetchOpts}).then(r => r.json());`
+    }
+    const v = varName(node.id)
+    const urlLiteral = toJsLiteral(url)
+    const scriptLines: string[] = [`const _${v}_url = new URL(${urlLiteral});`]
+    for (const [k, qv] of Object.entries(queryParams)) {
+      scriptLines.push(`_${v}_url.searchParams.set("${k}", ${toJsLiteral(qv)});`)
+    }
+    scriptLines.push(`const ${v} = await fetch(_${v}_url${fetchOpts}).then(r => r.json());`)
+    return scriptLines.join('\n')
   }
   return `const ${varName(node.id)} = await step.do("${escName(node.name)}"${configArg}, async () => {
 ${bodyCode}

--- a/packages/provider-cloudflare/src/codegen/generators/loop.ts
+++ b/packages/provider-cloudflare/src/codegen/generators/loop.ts
@@ -37,55 +37,83 @@ export function generateLoop(
   const rawBody = bodyChain.map((n) => generateNode(n, ir)).join('\n')
   exitLoop()
 
-  const bodyCode = suffixStepNames(rawBody, counterVar)
+  // Step-name suffixing only matters when the body actually contains
+  // step.do/step.sleep/etc calls — i.e. workflow mode with durable nodes
+  // inside the loop. In script mode the body is raw inline code, no step
+  // primitives, no suffixing needed.
+  const needsStepCounter = mode === 'workflow' && STEP_NAME_RE.test(rawBody)
+  const bodyCode = needsStepCounter ? suffixStepNames(rawBody, counterVar) : rawBody
   const indentedBody = indentCode(bodyCode, 4)
   const hasBody = indentedBody.trim().length > 0
   const usesOutput = OUTPUT_ASSIGN_RE.test(rawBody.replace(COMMENT_RE, ''))
 
-  const inner: string[] = []
-  inner.push('  let _output; // assign a value to return it from the loop')
+  const loopLines: string[] = []
 
   switch (loopType) {
     case 'forEach': {
       const collection = String(node.data.collection ?? '[]')
       const itemVar = String(node.data.itemVar ?? 'item')
-      inner.push(`  let ${counterVar} = 0;`)
-      inner.push(`  for (const ${itemVar} of ${collection}) {`)
-      if (hasBody) inner.push(indentedBody)
-      inner.push(`    ${counterVar}++;`)
-      inner.push('  }')
+      // forEach already provides the item via destructuring. Only when the
+      // body has step.METHOD calls do we also need an iteration index for
+      // unique step names — and then we get it from .entries() inline,
+      // not from a separate counter declaration.
+      if (needsStepCounter) {
+        loopLines.push(`  for (const [${counterVar}, ${itemVar}] of (${collection}).entries()) {`)
+      } else {
+        loopLines.push(`  for (const ${itemVar} of ${collection}) {`)
+      }
+      if (hasBody) loopLines.push(indentedBody)
+      loopLines.push('  }')
       break
     }
     case 'while': {
       const condition = String(node.data.condition ?? '').trim()
       const whileExpr = condition || 'true'
-      inner.push(`  let ${counterVar} = 0;`)
-      inner.push(`  while (${whileExpr}) {`)
-      if (hasBody) inner.push(indentedBody)
-      inner.push(`    ${counterVar}++;`)
-      inner.push('  }')
+      // While loops have no inherent index. Only emit the counter when
+      // it's actually used to suffix step names.
+      if (needsStepCounter) loopLines.push(`  let ${counterVar} = 0;`)
+      loopLines.push(`  while (${whileExpr}) {`)
+      if (hasBody) loopLines.push(indentedBody)
+      if (needsStepCounter) loopLines.push(`    ${counterVar}++;`)
+      loopLines.push('  }')
       break
     }
     case 'times': {
       const count = (node.data.count as number) ?? 5
-      inner.push(`  for (let ${counterVar} = 0; ${counterVar} < ${count}; ${counterVar}++) {`)
-      if (hasBody) inner.push(indentedBody)
-      inner.push('  }')
+      // The counter IS the loop iterator — always emitted.
+      loopLines.push(`  for (let ${counterVar} = 0; ${counterVar} < ${count}; ${counterVar}++) {`)
+      if (hasBody) loopLines.push(indentedBody)
+      loopLines.push('  }')
       break
     }
     default:
-      inner.push(`  // Unknown loop type: ${loopType}`)
+      loopLines.push(`  // Unknown loop type: ${loopType}`)
   }
 
-  inner.push('  return _output;')
-
-  const prefix = usesOutput ? `const ${varName(node.id)} = ` : ''
   if (mode === 'script') {
-    return `${prefix}await (async () => {
-${inner.join('\n')}
+    // Script mode: no step.do boundary, so emit the loop inline.
+    if (usesOutput) {
+      // Need to capture the body's _output assignment as a const. Wrap
+      // in an IIFE — that's the cheapest way to scope `let _output` and
+      // return its value into a `const X = ...` (which the EXPORT_
+      // post-processing in generateScript scans for).
+      return `const ${varName(node.id)} = await (async () => {
+  let _output; // assign a value to return it from the loop
+${loopLines.join('\n')}
+  return _output;
 })();`
+    }
+    // No output capture — emit the bare loop, no IIFE.
+    return loopLines.map((l) => l.replace(/^ {2}/, '')).join('\n')
   }
+
+  // Workflow mode: keep the step.do wrapper. The IIFE-style closure is
+  // required by step.do's signature. Always include _output declaration
+  // and return so the captured value (if any) flows out via const prefix.
+  const prefix = usesOutput ? `const ${varName(node.id)} = ` : ''
   return `${prefix}await step.do("${escName(node.name)}", async () => {
-${inner.join('\n')}
+  let _output; // assign a value to return it from the loop
+${loopLines.join('\n')}
+  return _output;
 });`
 }


### PR DESCRIPTION
## Summary

Four follow-up fixes triggered by a real-world script: a forEach loop sending mail to recipients, with `{{event.payload.recipients}}` as the collection. The user hit two bugs in one screenshot:

- **Save failed with "Expression references nonexistent node \"event\""** even though the generated code was correct (`event.payload.recipients` is a runtime accessor on the `runGraph(env, event)` parameter).
- **Generated loop body was wrapped in a redundant IIFE** with a dead `let _loop_i = 0; _loop_i++;` counter that was never read — leftover from the workflow→script port.

The fix takes four commits, each addressing one root cause:

1. **fix(ir): allow event/env/trigger as reserved expression refs** — `validateExpressionRefs` no longer rejects these runtime-provided identifiers. `RESERVED_EXPRESSION_REFS` is exported from `@awaitstep/ir` for downstream reuse.
2. **fix(provider-cloudflare): drop redundant IIFE in parallel/race script mode** — the script-mode generator was wrapping `Promise.allSettled([...].map(fn => fn()))` in an outer IIFE that added nothing. Inlined.
3. **fix(provider-cloudflare): flatten http_request script-mode codegen** — simple GETs collapse to `const X = await fetch(URL).then(r => r.json())`. Query-params case uses namespaced intermediate vars (`_<varName>_url`) so siblings don't collide. Final assignment keeps `const X =` so EXPORT_ post-processing still finds it.
4. **fix(provider-cloudflare): clean up loop codegen — drop dead counter and IIFE** — three sub-improvements:
   - In script mode without `_output` capture: no IIFE wrap, bare for-block.
   - `_loop_i` only emitted when the body has `step.METHOD` calls (workflow mode with durable nodes inside).
   - `forEach` uses `.entries()` for the index inline instead of a separate `let _loop_i = 0` declaration.

`while` keeps the conditional counter (no inherent index). `times` keeps `_loop_i` as the loop iterator (it IS the counter).

## Test plan

- [x] `pnpm test` — 18/18 task suites green (306 provider-cloudflare tests pass, 56 api, etc.). New test cases cover all 4 fixes.
- [ ] Manual: paste the user's reported `kind: "script"` IR with `{{event.payload.recipients}}` in a forEach Loop → save passes validation.
- [ ] Manual: deployed script's generated code shows the bare for-of with no `_loop_i = 0; _loop_i++;` cruft.
- [ ] Manual: a workflow-mode forEach Loop wrapping a `step.do(...)` body still emits unique step names per iteration via `.entries()` destructure.
- [ ] Manual: verify `parallel` / `race` / `http_request` all render without an outer IIFE in script mode.
- [ ] Back-compat: existing workflow-mode loops, http calls, parallel/race containers unchanged.