### PR TITLE
fix(api): source triggerCode from workflow row, drop duplicate from deployment config

### DIFF
--- a/apps/api/src/lib/deploy-prepare.ts
+++ b/apps/api/src/lib/deploy-prepare.ts
@@ -112,6 +112,7 @@ export async function prepareDeploy(
       ir: prepared.ir,
       ...(prepared.dependencies && { dependencies: prepared.dependencies }),
       ...(appName && { packageName: appName }),
+      ...(workflow.triggerCode && { triggerCode: workflow.triggerCode }),
       deploymentConfig: resolvedConfig.config,
     },
     envVars: prepared.envVars,
@@ -172,7 +173,12 @@ async function resolveDeploymentConfig(input: ResolveConfigInput): Promise<Resol
   // 2. Stored deployment config
   const stored = await db.getDeploymentConfig(workflowId, connectionId)
   if (stored) {
-    const parsed = adapter.deploymentConfigSchema.safeParse(JSON.parse(stored.config))
+    const storedConfig = JSON.parse(stored.config) as Record<string, unknown>
+    // Strip legacy `triggerCode` written by older deploys before it moved to
+    // workflow.triggerCode. Without this, strict() rejects the whole row and
+    // the user loses their saved routes/flags.
+    delete storedConfig.triggerCode
+    const parsed = adapter.deploymentConfigSchema.safeParse(storedConfig)
     if (parsed.success) {
       return { config: parsed.data }
     }
@@ -194,12 +200,11 @@ async function resolveDeploymentConfig(input: ResolveConfigInput): Promise<Resol
 
 function normalizeLegacyConfig(workflow: Workflow): unknown | undefined {
   const legacy = workflow.deployConfig ? JSON.parse(workflow.deployConfig) : undefined
-  if (!legacy && !workflow.triggerCode) return undefined
+  if (!legacy) return undefined
 
   return {
     ...(legacy?.route && {
       routes: [{ pattern: legacy.route.pattern, zoneName: legacy.route.zoneName }],
     }),
-    ...(workflow.triggerCode && { triggerCode: workflow.triggerCode }),
   }
 }

--- a/packages/provider-cloudflare/src/__tests__/config-schema.test.ts
+++ b/packages/provider-cloudflare/src/__tests__/config-schema.test.ts
@@ -11,14 +11,20 @@ describe('cloudflareDeploymentConfigSchema', () => {
     expect(cloudflareDeploymentConfigSchema.safeParse({}).success).toBe(true)
   })
 
-  it('accepts routes, toggles, and triggerCode', () => {
+  it('accepts routes and toggles', () => {
     const parsed = cloudflareDeploymentConfigSchema.safeParse({
       routes: [{ pattern: 'example.com/*', zoneName: 'example.com' }],
       workersDev: true,
       previewUrls: false,
-      triggerCode: 'export default {}',
     })
     expect(parsed.success).toBe(true)
+  })
+
+  it('rejects triggerCode (workflow-level field, not a deployment setting)', () => {
+    const parsed = cloudflareDeploymentConfigSchema.safeParse({
+      triggerCode: 'export default {}',
+    })
+    expect(parsed.success).toBe(false)
   })
 
   it('rejects routes missing zoneName', () => {

--- a/packages/provider-cloudflare/src/adapter.ts
+++ b/packages/provider-cloudflare/src/adapter.ts
@@ -141,8 +141,7 @@ export class CloudflareWorkflowsAdapter implements WorkflowProvider, LocalDevPro
 
   generate(ir: ArtifactIR, config?: ProviderConfig): GeneratedArtifact {
     const envVarNames = config?.envVars ? Object.keys(config.envVars) : undefined
-    const dc = config?.options?.['deploymentConfig'] as CloudflareDeploymentConfig | undefined
-    const triggerCode = dc?.triggerCode ?? (config?.options?.['triggerCode'] as string | undefined)
+    const triggerCode = config?.options?.['triggerCode'] as string | undefined
     if (ir.kind === 'script') {
       const source = generateScript(ir as ScriptIR, {
         templateResolver: this.templateResolver,

--- a/packages/provider-cloudflare/src/config-schema.ts
+++ b/packages/provider-cloudflare/src/config-schema.ts
@@ -50,9 +50,6 @@ export const cloudflareDeploymentConfigSchema = z
       )
       .optional(),
     logpush: z.boolean().optional(),
-
-    // Advanced (hidden from UI)
-    triggerCode: z.string().optional(),
   })
   .strict()
 


### PR DESCRIPTION
## Summary

The deploy pipeline was silently discarding the user's saved fetch handler body (`workflow.triggerCode`) and substituting `DEFAULT_SCRIPT_TRIGGER_CODE` instead. For users whose triggerCode contained imports (e.g. `import puppeteer from "@cloudflare/puppeteer"`), the deployed worker bundled without the import → runtime `ReferenceError`.

**Root cause.** `triggerCode` was duplicated as a field in `cloudflareDeploymentConfigSchema` (legacy port from `workflow.deployConfig` JSON when the schema was first introduced in `0bbc3fb`). The deploy form sends `config: {}` from the web when no overrides exist; the resolver treated the empty `{}` as a valid override (path 1 wins in `resolveDeploymentConfig`), the parsed config had no `triggerCode`, and the adapter fell back to the default. The user's `workflow.triggerCode` row was never read on the deploy path even though `workflow-prepare.ts:114` already wired it correctly.

**Fix.** `triggerCode` is workflow-level user code, not a per-deploy setting. Removed it from `cloudflareDeploymentConfigSchema`, simplified the adapter to read only from `options.triggerCode`, and pass `workflow.triggerCode` directly into `providerConfig.options` in `deploy-prepare.ts`. Added a one-line shim that strips the legacy `triggerCode` field from any stored deployment configs before strict parsing, so existing rows preserve their saved routes/flags during the transition.

## Test plan

- [x] `pnpm test` (307 cloudflare, 56 api — all green)
- [x] `pnpm lint`
- [x] `pnpm type-check`
- [x] `pnpm build`
- [x] New test: schema rejects `triggerCode` (locks in the field removal)
- [ ] Manual: redeploy a script with a custom triggerCode containing imports — confirm import survives bundling and runtime works