### PR TITLE
fix(sandbox): pin wrangler to v4.82.2 and call binary directly

### DIFF
--- a/apps/api/Dockerfile.sandbox
+++ b/apps/api/Dockerfile.sandbox
@@ -1,14 +1,15 @@
 FROM docker.io/cloudflare/sandbox:0.9.2
 
-RUN curl -fsSL https://deb.nodesource.com/setup_22.x | bash - && apt-get install -y nodejs
-
 # Pre-install wrangler globally so deploys don't pay ~30s npm install cost.
 # The sandbox is ephemeral (created + destroyed per deploy), but the Docker
 # image is cached across runs.
 #
+# Pinned to 4.82.2 — last v4 release that supports Node 20 (engines: ">=20.3.0").
+# The cloudflare/sandbox base image ships Node 20; v4.83+ requires Node 22.
+#
 # Instance type should be at least "basic" (1/4 vCPU, 1 GiB memory, 4 GB disk).
 # "lite" (256 MiB) is not enough for wrangler + npm install + esbuild.
-RUN npm install -g wrangler@latest
+RUN npm install -g wrangler@4.82.2
 
 # Working directory for deploy artifacts (worker.ts, wrangler.json, package.json)
 RUN mkdir -p /workspace

--- a/packages/provider-cloudflare/src/__tests__/sandbox-deployer.test.ts
+++ b/packages/provider-cloudflare/src/__tests__/sandbox-deployer.test.ts
@@ -99,7 +99,7 @@ describe('SandboxWranglerDeployer', () => {
     const bulkCall = lastSandbox!.execCalls.find((c) => c.command.includes('secret bulk'))
     expect(bulkCall).toBeDefined()
     expect(bulkCall!.command).toBe(
-      'npx wrangler secret bulk .secrets.bulk.json --name awaitstep-my-workflow',
+      'wrangler secret bulk .secrets.bulk.json --name awaitstep-my-workflow',
     )
     expect(bulkCall!.cwd).toBe('/workspace')
     expect(bulkCall!.env?.CLOUDFLARE_API_TOKEN).toBe('token123')

--- a/packages/provider-cloudflare/src/deploy/sandbox-deployer.ts
+++ b/packages/provider-cloudflare/src/deploy/sandbox-deployer.ts
@@ -106,7 +106,7 @@ export class SandboxWranglerDeployer implements WranglerDeployer {
 
       // 4. Deploy with wrangler
       onProgress?.('DEPLOYING', 'Uploading worker to Cloudflare...')
-      const deployResult = await sandbox.exec('npx wrangler deploy', {
+      const deployResult = await sandbox.exec('wrangler deploy', {
         cwd: '/workspace',
         timeout: 120_000,
         env: {
@@ -142,7 +142,7 @@ export class SandboxWranglerDeployer implements WranglerDeployer {
         await sandbox.writeFile(secretsPath, bulk.json)
         try {
           const bulkResult = await sandbox.exec(
-            `npx wrangler secret bulk ${SECRETS_BULK_FILENAME} --name ${name}`,
+            `wrangler secret bulk ${SECRETS_BULK_FILENAME} --name ${name}`,
             {
               cwd: '/workspace',
               env: {
@@ -188,17 +188,14 @@ export class SandboxWranglerDeployer implements WranglerDeployer {
     const sandboxId = `delete-${workerNameToDelete}-${Date.now()}`.toLowerCase()
     const sandbox = this.getSandbox(sandboxId)
     try {
-      const result = await sandbox.exec(
-        `npx wrangler delete --name ${workerNameToDelete} --force`,
-        {
-          cwd: '/workspace',
-          env: {
-            CLOUDFLARE_ACCOUNT_ID: options.accountId,
-            CLOUDFLARE_API_TOKEN: options.apiToken,
-          },
-          timeout: 60_000,
+      const result = await sandbox.exec(`wrangler delete --name ${workerNameToDelete} --force`, {
+        cwd: '/workspace',
+        env: {
+          CLOUDFLARE_ACCOUNT_ID: options.accountId,
+          CLOUDFLARE_API_TOKEN: options.apiToken,
         },
-      )
+        timeout: 60_000,
+      })
       return result.success
         ? { success: true }
         : { success: false, error: redactSensitive(result.stderr) }


### PR DESCRIPTION
## Summary

The cloudflare/sandbox:0.9.2 base image ships Node 20.20.2. The previous attempt to layer NodeSource Node 22 on top didn't actually take effect — the base image puts node in /usr/local/bin (which has PATH precedence over apt's /usr/bin), so npm still saw Node 20 and \`wrangler@latest\` (v4.83+, requires Node 22) failed at runtime with \`Wrangler requires at least Node.js v22.0.0\`.

- **Drop** the NodeSource Node 22 install layer from \`Dockerfile.sandbox\`.
- **Pin** wrangler to \`4.82.2\` — the last v4 release with engines \`node >=20.3.0\`. Verified via \`npm view wrangler@4.82.2 engines\`.
- **Switch** \`sandbox.exec\` calls in \`sandbox-deployer.ts\` from \`npx wrangler ...\` to \`wrangler ...\`. The binary is pre-installed globally; calling it directly skips npx's local-bin lookup, which means a user-bundled \`wrangler\` in their workflow's \`node_modules\` can no longer override our pinned version.

## Test plan

- [x] \`pnpm test\` (307 cloudflare tests pass; sandbox-deployer test fixture updated to match new command shape)
- [x] \`pnpm lint\`
- [x] \`pnpm type-check\`
- [x] \`pnpm build\`
- [ ] Manual: deploy a script to confirm \`wrangler deploy\` runs and \`wrangler secret bulk\` succeeds in the sandbox container