### PR TITLE
fix(deploy): surface user-code syntax errors instead of silent success

### DIFF
--- a/apps/api/src/lib/workflow-prepare.ts
+++ b/apps/api/src/lib/workflow-prepare.ts
@@ -1,4 +1,5 @@
 import type { WorkflowProvider, GeneratedArtifact, ProviderConfig } from '@awaitstep/codegen'
+import { transpileToJS } from '@awaitstep/codegen/transpile'
 import type { ArtifactIR } from '@awaitstep/ir'
 import type { DatabaseAdapter, Workflow } from '@awaitstep/db'
 import type { AppNodeRegistry } from './node-registry.js'
@@ -114,6 +115,16 @@ export async function prepareWorkflow(
     ...(workflow.triggerCode && { options: { triggerCode: workflow.triggerCode } }),
   }
   const artifact = adapter.generate(ir, generateConfig)
+
+  // Catch syntax errors in user-authored code (step bodies, triggerCode, etc.)
+  // before deploy/preview consumers act on the artifact. Without this the
+  // sucrase exception bubbles up and surfaces as a generic 500.
+  try {
+    await transpileToJS(artifact.source)
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err)
+    return { error: `Compile error: ${message}`, status: 422 }
+  }
 
   return {
     adapter,

--- a/apps/api/src/routes/deploy.ts
+++ b/apps/api/src/routes/deploy.ts
@@ -124,15 +124,24 @@ deploy.post('/:workflowId/deploy-stream', zValidator('json', deploySchema), asyn
     const hasProgressDeploy =
       'deployWithProgress' in adapter && typeof adapterRecord.deployWithProgress === 'function'
 
-    const result = hasProgressDeploy
-      ? await (
-          adapterRecord.deployWithProgress as (
-            a: GeneratedArtifact,
-            c: ProviderConfig,
-            p: (progress: unknown) => Promise<void>,
-          ) => Promise<DeployResult>
-        )(artifact, providerConfig, onProgress)
-      : await adapter.deploy(artifact, providerConfig)
+    let result: DeployResult
+    try {
+      result = hasProgressDeploy
+        ? await (
+            adapterRecord.deployWithProgress as (
+              a: GeneratedArtifact,
+              c: ProviderConfig,
+              p: (progress: unknown) => Promise<void>,
+            ) => Promise<DeployResult>
+          )(artifact, providerConfig, onProgress)
+        : await adapter.deploy(artifact, providerConfig)
+    } catch (err) {
+      // Adapter contract is to return DeployResult; an uncaught exception is
+      // a provider bug. Without this catch the SSE stream would close silently
+      // and the client would see no failure event.
+      const message = err instanceof Error ? err.message : String(err)
+      result = { success: false, deploymentId: '', error: message }
+    }
 
     await db.createDeployment({
       id: nanoid(),

--- a/packages/provider-cloudflare/src/__tests__/adapter.test.ts
+++ b/packages/provider-cloudflare/src/__tests__/adapter.test.ts
@@ -162,6 +162,23 @@ describe('CloudflareWorkflowsAdapter', () => {
       expect(deployOpts.routes).toBeUndefined()
     })
 
+    it('returns a structured Compile error when transpile fails (does not throw)', async () => {
+      const brokenIR: WorkflowIR = {
+        ...simpleIR,
+        nodes: [
+          {
+            ...simpleIR.nodes[0]!,
+            // Missing comma between properties — sucrase will reject this.
+            data: { code: 'const obj = { a: 1\n  b: 2 }; return obj;' },
+          },
+        ],
+      }
+      const artifact = adapter.generate(brokenIR)
+      const result = await adapter.deploy(artifact, providerConfig)
+      expect(result.success).toBe(false)
+      expect(result.error).toMatch(/^Compile error:/)
+    })
+
     it('excludes _BINDING_ID env vars from wrangler vars', async () => {
       const artifact = adapter.generate(simpleIR)
       const configWithBindingIds: ProviderConfig = {

--- a/packages/provider-cloudflare/src/adapter.ts
+++ b/packages/provider-cloudflare/src/adapter.ts
@@ -197,7 +197,18 @@ export class CloudflareWorkflowsAdapter implements WorkflowProvider, LocalDevPro
     }
 
     report('GENERATING_CODE', 'Compiling TypeScript to JavaScript', 15)
-    const compiled = await transpileToJS(artifact.source)
+    let compiled: string
+    try {
+      compiled = await transpileToJS(artifact.source)
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err)
+      report('FAILED', `Compile error: ${message}`, 0)
+      return {
+        success: false,
+        deploymentId: '',
+        error: `Compile error: ${message}`,
+      }
+    }
     const compiledArtifact: GeneratedArtifact = {
       filename: 'worker.js',
       source: artifact.source,
@@ -425,7 +436,13 @@ export class CloudflareWorkflowsAdapter implements WorkflowProvider, LocalDevPro
     artifact: GeneratedArtifact,
     options: LocalDevOptions,
   ): Promise<LocalDevSession> {
-    const compiled = await transpileToJS(artifact.source)
+    let compiled: string
+    try {
+      compiled = await transpileToJS(artifact.source)
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err)
+      throw new Error(`Compile error: ${message}`, { cause: err })
+    }
     return startLocalDev({ filename: 'worker.js', source: artifact.source, compiled }, options)
   }
 }


### PR DESCRIPTION
## Summary

Sucrase throws on syntax errors in user-authored step bodies and trigger code (e.g. a missing comma in an object literal), but nothing along the deploy path was catching that. The exception bubbled out of `adapter.deploy()` into the streamSSE handler, which closed the stream without emitting a result event — the client interpreted that as "deploy succeeded" and the user got no signal that their code was broken.

Three layers of defense:

- **`adapter.ts`** — wrap both `transpileToJS` calls (deploy + `startLocalDev`) in try/catch. Deploy now returns a structured `DeployResult { success: false, error: "Compile error: <message>" }` and reports a `FAILED` progress stage; `startLocalDev` re-throws with `Error.cause` preserved.
- **`deploy.ts` (streamSSE handler)** — wrap `adapter.deploy(WithProgress)` in try/catch as a backstop. Any provider that ever throws by mistake now produces a `{ success: false, error }` result that flows into the DB write + SSE result event instead of silently ending the stream.
- **`workflow-prepare.ts`** — after `adapter.generate()`, run `transpileToJS` on the artifact source. Returns 422 with `Compile error: …` if it fails, so the editor surfaces the error at preview/save time — the user doesn't have to wait for a deploy to discover the typo.

## Test plan

- [x] `pnpm test` (308 cloudflare, 56 api — +1 new test for the compile-error path)
- [x] `pnpm lint`
- [x] `pnpm type-check`
- [x] `pnpm build`
- [ ] Manual: deploy a script with a syntax error in a step body → confirm the deploy returns "Compile error: …" instead of silently appearing to succeed
- [ ] Manual: open a workflow whose triggerCode has a syntax error → confirm preview returns 422 with the error message