### PR TITLE
feat(codegen): annotated multi-handler workers (@fetch, @queue, @config)

### DIFF
--- a/apps/web/src/components/canvas/bindings-panel.tsx
+++ b/apps/web/src/components/canvas/bindings-panel.tsx
@@ -12,7 +12,9 @@ import {
   Zap,
   Globe,
   Link,
+  Plus,
 } from 'lucide-react'
+import { deriveQueueName } from '@awaitstep/provider-cloudflare/codegen'
 import { useWorkflowStore } from '../../stores/workflow-store'
 import {
   detectBindingsFromNodes,
@@ -34,9 +36,33 @@ const BINDING_META: Record<ClientBindingType, { label: string; icon: typeof Data
   service: { label: 'Service', icon: Link },
 }
 
+/**
+ * Returns true if the trigger code already declares a `@queue function NAME(...)`
+ * for the given queue name. Plain regex — assumes annotations live at top
+ * level (matches our parser's contract).
+ */
+function hasQueueHandler(triggerCode: string, queueName: string): boolean {
+  const re = new RegExp(`@queue\\s+function\\s+${queueName}\\s*\\(`)
+  return re.test(triggerCode)
+}
+
+function buildConsumeSnippet(queueName: string): string {
+  return `
+
+@queue function ${queueName}(batch, env, ctx) {
+  for (const msg of batch.messages) {
+    // process msg.body
+    msg.ack()
+  }
+}`
+}
+
 export function BindingsPanel() {
   const [expanded, setExpanded] = useState(false)
   const nodes = useWorkflowStore((s) => s.nodes)
+  const triggerCode = useWorkflowStore((s) => s.triggerCode)
+  const setTriggerCode = useWorkflowStore((s) => s.setTriggerCode)
+  const setShowEditor = useWorkflowStore((s) => s.setShowEditor)
 
   const bindings: ClientBinding[] = useMemo(() => {
     if (nodes.length === 0) return []
@@ -44,6 +70,15 @@ export function BindingsPanel() {
   }, [nodes])
 
   if (bindings.length === 0) return null
+
+  const handleConsumeClick = (bindingName: string) => {
+    const queueName = deriveQueueName(bindingName)
+    if (!hasQueueHandler(triggerCode, queueName)) {
+      setTriggerCode(triggerCode + buildConsumeSnippet(queueName))
+    }
+    // Open the code editor so the user sees the inserted handler in context.
+    setShowEditor(true)
+  }
 
   return (
     <div className="absolute top-4 right-4 z-10">
@@ -68,6 +103,10 @@ export function BindingsPanel() {
             {bindings.map((binding) => {
               const meta = BINDING_META[binding.type]
               const Icon = meta.icon
+              const isQueue = binding.type === 'queue'
+              const queueName = isQueue ? deriveQueueName(binding.name) : null
+              const alreadyConsumed =
+                isQueue && queueName !== null && hasQueueHandler(triggerCode, queueName)
               return (
                 <div
                   key={`${binding.type}:${binding.name}`}
@@ -83,6 +122,19 @@ export function BindingsPanel() {
                     {meta.label}
                   </span>
                   <span className="font-mono text-foreground/70">{binding.name}</span>
+                  {isQueue &&
+                    (alreadyConsumed ? (
+                      <span className="text-muted-foreground/60 text-xs italic">consumed</span>
+                    ) : (
+                      <button
+                        onClick={() => handleConsumeClick(binding.name)}
+                        className="ml-auto flex items-center gap-1 rounded px-1.5 py-0.5 text-xs text-primary hover:bg-primary/10"
+                        title={`Add @queue function ${queueName}(...) to trigger code`}
+                      >
+                        <Plus className="h-3 w-3" />
+                        Consume
+                      </button>
+                    ))}
                 </div>
               )
             })}

--- a/apps/web/src/components/canvas/editor-panel.tsx
+++ b/apps/web/src/components/canvas/editor-panel.tsx
@@ -7,7 +7,8 @@ import {
 } from '@awaitstep/provider-cloudflare/codegen'
 import type { ScriptIR, WorkflowIR } from '@awaitstep/ir'
 import type { TemplateResolver } from '@awaitstep/codegen'
-import { Copy, Check, RotateCcw, ChevronDown, ChevronRight } from 'lucide-react'
+import { Copy, Check, RotateCcw, ChevronDown, ChevronRight, Info } from 'lucide-react'
+import * as Tooltip from '@radix-ui/react-tooltip'
 import { Button } from '../ui/button'
 import { useOrgStore } from '../../stores/org-store'
 import { useWorkflowStore } from '../../stores/workflow-store'
@@ -19,6 +20,98 @@ const MonacoEditor = lazy(() => import('@monaco-editor/react'))
 
 type Tab = 'code' | 'preview'
 type OutputMode = 'typescript' | 'ir-json'
+
+function EditorHelpTooltip({ isScript }: { isScript: boolean }) {
+  return (
+    <Tooltip.Provider delayDuration={150}>
+      <Tooltip.Root>
+        <Tooltip.Trigger asChild>
+          <button
+            type="button"
+            className="inline-flex h-4 w-4 items-center justify-center rounded-full text-muted-foreground/40 transition-colors hover:bg-muted/60 hover:text-muted-foreground"
+            aria-label="How the code editor works"
+          >
+            <Info size={12} />
+          </button>
+        </Tooltip.Trigger>
+        <Tooltip.Portal>
+          <Tooltip.Content
+            side="bottom"
+            align="start"
+            sideOffset={6}
+            className="z-50 max-w-md rounded-lg border border-border bg-card p-4 shadow-lg"
+          >
+            <p className="text-xs font-medium text-foreground">
+              How the {isScript ? 'script' : 'workflow'} editor works
+            </p>
+            <div className="mt-2 space-y-2 text-xs leading-relaxed text-muted-foreground">
+              <p>Declare top-level handlers anywhere in the file:</p>
+              <ul className="ml-3 space-y-1.5">
+                <li>
+                  <code className="rounded bg-muted/60 px-1 py-0.5 font-mono">
+                    @fetch function handler(request, env, ctx)
+                  </code>
+                  <br />
+                  HTTP entry point.{' '}
+                  {isScript
+                    ? 'Typically calls runGraph(env, event) and returns Response.json(graph).'
+                    : 'Typically creates an instance via env.WORKFLOW.create({ params }) and returns its id.'}
+                </li>
+                <li>
+                  <code className="rounded bg-muted/60 px-1 py-0.5 font-mono">
+                    @queue function NAME(batch, env, ctx)
+                  </code>
+                  <br />
+                  Consumes messages from queue <code className="font-mono">NAME</code>. CF delivers
+                  a batch; ack/retry per message. Add{' '}
+                  <code className="rounded bg-muted/60 px-1 py-0.5 font-mono">
+                    @config {`{ max_batch_size: 1, max_retries: 3, ... }`}
+                  </code>{' '}
+                  at the start of the body for per-queue tuning.
+                </li>
+              </ul>
+              {isScript ? (
+                <p>
+                  Your canvas nodes are compiled into{' '}
+                  <code className="rounded bg-muted/60 px-1 py-0.5 font-mono">
+                    runGraph(env, event)
+                  </code>
+                  . Call it from any handler. Outputs from steps named{' '}
+                  <code className="rounded bg-muted/60 px-1 py-0.5 font-mono">EXPORT_X</code>{' '}
+                  surface on{' '}
+                  <code className="rounded bg-muted/60 px-1 py-0.5 font-mono">graph.X</code>.
+                </p>
+              ) : (
+                <p>
+                  Your canvas nodes are compiled into a{' '}
+                  <code className="rounded bg-muted/60 px-1 py-0.5 font-mono">
+                    WorkflowEntrypoint
+                  </code>{' '}
+                  class with durable steps (<code className="font-mono">step.do</code>,{' '}
+                  <code className="font-mono">step.sleep</code>, etc.). Trigger it from{' '}
+                  <code className="rounded bg-muted/60 px-1 py-0.5 font-mono">@fetch</code> via{' '}
+                  <code className="rounded bg-muted/60 px-1 py-0.5 font-mono">env.WORKFLOW</code>.
+                </p>
+              )}
+              <p>
+                Top-level <code className="rounded bg-muted/60 px-1 py-0.5 font-mono">import</code>{' '}
+                statements (declared anywhere — including inside handler bodies) are hoisted to
+                module scope. Code outside annotated handlers becomes module-level (shared helpers,
+                constants).
+              </p>
+              <p className="text-muted-foreground/60">
+                With no annotations, the entire file is treated as the{' '}
+                <code className="rounded bg-muted/60 px-1 py-0.5 font-mono">fetch()</code> body
+                (legacy mode, preserved for backward compatibility).
+              </p>
+            </div>
+            <Tooltip.Arrow className="fill-card" />
+          </Tooltip.Content>
+        </Tooltip.Portal>
+      </Tooltip.Root>
+    </Tooltip.Provider>
+  )
+}
 
 export function EditorPanel() {
   const { kind, metadata, nodes, edges, triggerCode, dependencies } = useWorkflowStore(
@@ -278,17 +371,12 @@ export function EditorPanel() {
 
           {/* Entry code hint */}
           <div className="border-b border-border px-4 py-2">
-            {isScript ? (
-              <p className="text-xs leading-relaxed text-muted-foreground/40">
-                Body of{' '}
-                <code className="rounded bg-muted/60 px-1 py-0.5 font-mono text-xs">fetch()</code>.
-                Graph nodes run inside{' '}
-                <code className="rounded bg-muted/60 px-1 py-0.5 font-mono text-xs">
-                  runGraph()
-                </code>{' '}
-                — call it and reference outputs via{' '}
-                <code className="rounded bg-muted/60 px-1 py-0.5 font-mono text-xs">graph.*</code>.
-                {graphOutputs.length > 0 && (
+            <div className="flex items-center gap-1.5 text-xs leading-relaxed text-muted-foreground/40">
+              <span>
+                Worker source. Annotated handlers (
+                <code className="rounded bg-muted/60 px-1 py-0.5 font-mono text-xs">@fetch</code>,{' '}
+                <code className="rounded bg-muted/60 px-1 py-0.5 font-mono text-xs">@queue</code>).
+                {isScript && graphOutputs.length > 0 && (
                   <>
                     {' '}
                     Available:{' '}
@@ -303,16 +391,9 @@ export function EditorPanel() {
                     .
                   </>
                 )}
-              </p>
-            ) : (
-              <p className="text-xs leading-relaxed text-muted-foreground/40">
-                Code for the{' '}
-                <code className="rounded bg-muted/60 px-1 py-0.5 font-mono text-xs">fetch()</code>{' '}
-                handler. Write{' '}
-                <code className="rounded bg-muted/60 px-1 py-0.5 font-mono text-xs">import</code>{' '}
-                statements at the top — they are hoisted automatically.
-              </p>
-            )}
+              </span>
+              <EditorHelpTooltip isScript={isScript} />
+            </div>
           </div>
 
           {/* Entry code editor */}

--- a/apps/web/src/routes/_authed/workflows/$workflowId.canvas.tsx
+++ b/apps/web/src/routes/_authed/workflows/$workflowId.canvas.tsx
@@ -75,7 +75,8 @@ function WorkflowEditorPage() {
   } = useSearch({
     from: '/_authed/workflows/$workflowId/canvas',
   })
-  const [showEditor, setShowEditor] = useState(false)
+  const showEditor = useWorkflowStore((s) => s.showEditor)
+  const setShowEditor = useWorkflowStore((s) => s.setShowEditor)
   const [showLocalTest, setShowLocalTest] = useState(false)
   // Functions never show the template picker — templates are workflow-shaped.
   const [showTemplatePicker, setShowTemplatePicker] = useState(template && kindParam !== 'script')

--- a/apps/web/src/stores/workflow-store.ts
+++ b/apps/web/src/stores/workflow-store.ts
@@ -75,6 +75,7 @@ const getInitialWorkflowState = () => ({
   triggerCode: '',
   deployConfig: {},
   showSettings: false,
+  showEditor: false,
   validationResult: null,
   simulationResult: null,
   isDirty: false,
@@ -95,6 +96,7 @@ interface WorkflowState {
   triggerCode: string
   deployConfig: DeployConfig
   showSettings: boolean
+  showEditor: boolean
   validationResult: PublishValidationResult | null
   simulationResult: SimulationResult | null
   isDirty: boolean
@@ -123,6 +125,7 @@ interface WorkflowState {
   setTriggerCode: (code: string) => void
   setDeployConfig: (config: DeployConfig) => void
   setShowSettings: (show: boolean) => void
+  setShowEditor: (show: boolean) => void
   runValidation: (nodeRegistry?: NodeRegistry) => PublishValidationResult
   clearValidation: () => void
   runSimulation: () => SimulationResult
@@ -421,6 +424,10 @@ export const useWorkflowStore = create<WorkflowState>((set, get) => ({
 
   setShowSettings: (show) => {
     set({ showSettings: show, selectedNodeId: show ? null : get().selectedNodeId })
+  },
+
+  setShowEditor: (show) => {
+    set({ showEditor: show })
   },
 
   runValidation: (nodeRegistry?: NodeRegistry) => {

--- a/packages/provider-cloudflare/src/__tests__/adapter.test.ts
+++ b/packages/provider-cloudflare/src/__tests__/adapter.test.ts
@@ -287,4 +287,60 @@ describe('buildQueueConsumers', () => {
     const triggerCode = `@fetch function notHandler() {}`
     expect(buildQueueConsumers(triggerCode, undefined)).toBeUndefined()
   })
+
+  it('applies inline @config block as the per-queue default', () => {
+    const triggerCode = `
+@queue function emails(b, e, c) {
+  @config {
+    max_batch_size: 1,
+    max_retries: 5,
+    dead_letter_queue: "emails-dlq"
+  }
+  msg.ack()
+}
+`
+    const result = buildQueueConsumers(triggerCode, undefined)
+    expect(result).toEqual([
+      {
+        queue: 'emails',
+        maxBatchSize: 1,
+        maxRetries: 5,
+        deadLetterQueue: 'emails-dlq',
+      },
+    ])
+  })
+
+  it('deploymentConfig override wins over inline @config (per-environment tuning)', () => {
+    const triggerCode = `
+@queue function emails(b, e, c) {
+  @config { max_batch_size: 1, max_retries: 5 }
+}
+`
+    const result = buildQueueConsumers(triggerCode, {
+      queueConsumers: [{ queue: 'emails', maxBatchSize: 50 }],
+    })
+    expect(result).toEqual([
+      {
+        queue: 'emails',
+        maxBatchSize: 50, // override wins
+        maxRetries: 5, // from inline @config (not overridden)
+      },
+    ])
+  })
+
+  it('different queues can have different inline @config blocks', () => {
+    const triggerCode = `
+@queue function emails(b, e, c) {
+  @config { max_batch_size: 50 }
+}
+@queue function jobs(b, e, c) {
+  @config { max_batch_size: 1, max_concurrency: 20 }
+}
+`
+    const result = buildQueueConsumers(triggerCode, undefined)
+    expect(result).toEqual([
+      { queue: 'emails', maxBatchSize: 50 },
+      { queue: 'jobs', maxBatchSize: 1, maxConcurrency: 20 },
+    ])
+  })
 })

--- a/packages/provider-cloudflare/src/__tests__/adapter.test.ts
+++ b/packages/provider-cloudflare/src/__tests__/adapter.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, vi } from 'vitest'
 import type { WorkflowIR } from '@awaitstep/ir'
 import type { ProviderConfig } from '@awaitstep/codegen'
-import { CloudflareWorkflowsAdapter } from '../adapter.js'
+import { CloudflareWorkflowsAdapter, buildQueueConsumers } from '../adapter.js'
 import type { WranglerDeployer } from '../deploy/deployer.js'
 
 const mockDeployer: WranglerDeployer = {
@@ -211,5 +211,80 @@ describe('CloudflareWorkflowsAdapter', () => {
       expect(result.status).toBe('complete')
       expect(result.output).toEqual({ result: 42 })
     })
+  })
+})
+
+describe('buildQueueConsumers', () => {
+  it('returns undefined when triggerCode is missing', () => {
+    expect(buildQueueConsumers(undefined, undefined)).toBeUndefined()
+  })
+
+  it('returns undefined for legacy-mode trigger code (no annotations)', () => {
+    expect(
+      buildQueueConsumers('try { return new Response() } catch(e) {}', undefined),
+    ).toBeUndefined()
+  })
+
+  it('returns undefined when strict mode has no @queue handlers', () => {
+    const triggerCode = `@fetch function handler(req, env, ctx) { return new Response() }`
+    expect(buildQueueConsumers(triggerCode, undefined)).toBeUndefined()
+  })
+
+  it('emits one entry per @queue annotation with no overrides', () => {
+    const triggerCode = `
+@queue function emails(b, e, c) { /* */ }
+@queue function jobs(b, e, c) { /* */ }
+`
+    const result = buildQueueConsumers(triggerCode, undefined)
+    expect(result).toEqual([{ queue: 'emails' }, { queue: 'jobs' }])
+  })
+
+  it('merges per-queue settings from deploymentConfig.queueConsumers', () => {
+    const triggerCode = `@queue function emails(b, e, c) {}`
+    const result = buildQueueConsumers(triggerCode, {
+      queueConsumers: [
+        {
+          queue: 'emails',
+          maxBatchSize: 5,
+          maxRetries: 1,
+          deadLetterQueue: 'emails-dlq',
+        },
+      ],
+    })
+    expect(result).toEqual([
+      {
+        queue: 'emails',
+        maxBatchSize: 5,
+        maxRetries: 1,
+        deadLetterQueue: 'emails-dlq',
+      },
+    ])
+  })
+
+  it('ignores queueConsumers entries that do not match any @queue annotation', () => {
+    const triggerCode = `@queue function emails(b, e, c) {}`
+    const result = buildQueueConsumers(triggerCode, {
+      queueConsumers: [
+        { queue: 'emails', maxBatchSize: 25 },
+        { queue: 'orphan', maxBatchSize: 100 },
+      ],
+    })
+    expect(result).toEqual([{ queue: 'emails', maxBatchSize: 25 }])
+  })
+
+  it('falls back to defaults (no overrides) when deploymentConfig has no entry for a queue', () => {
+    const triggerCode = `
+@queue function emails(b, e, c) {}
+@queue function jobs(b, e, c) {}
+`
+    const result = buildQueueConsumers(triggerCode, {
+      queueConsumers: [{ queue: 'emails', maxBatchSize: 5 }],
+    })
+    expect(result).toEqual([{ queue: 'emails', maxBatchSize: 5 }, { queue: 'jobs' }])
+  })
+
+  it('returns undefined on annotation parse error (already surfaced by generate)', () => {
+    const triggerCode = `@fetch function notHandler() {}`
+    expect(buildQueueConsumers(triggerCode, undefined)).toBeUndefined()
   })
 })

--- a/packages/provider-cloudflare/src/__tests__/codegen/bindings.test.ts
+++ b/packages/provider-cloudflare/src/__tests__/codegen/bindings.test.ts
@@ -1,6 +1,28 @@
 import { describe, it, expect } from 'vitest'
-import { detectBindings } from '../../codegen/bindings.js'
+import { detectBindings, deriveQueueName } from '../../codegen/bindings.js'
 import type { WorkflowIR, WorkflowNode } from '@awaitstep/ir'
+
+describe('deriveQueueName', () => {
+  it('strips QUEUE_ prefix and lowercases', () => {
+    expect(deriveQueueName('QUEUE_EMAILS')).toBe('emails')
+    expect(deriveQueueName('QUEUE_JOBS_HIGH')).toBe('jobs_high')
+  })
+
+  it('handles bare QUEUE binding by lowercasing the original', () => {
+    expect(deriveQueueName('QUEUE')).toBe('queue')
+  })
+
+  it('is case-insensitive on the prefix', () => {
+    expect(deriveQueueName('queue_emails')).toBe('emails')
+    expect(deriveQueueName('Queue_emails')).toBe('emails')
+  })
+
+  it('passes non-QUEUE bindings through (lowercased)', () => {
+    // Defensive: shouldn't be called with non-queue bindings, but if so,
+    // returns a sensible value rather than throwing.
+    expect(deriveQueueName('FOO_BAR')).toBe('foo_bar')
+  })
+})
 
 const V = '1.0.0'
 const P = 'cloudflare'

--- a/packages/provider-cloudflare/src/__tests__/codegen/generate-script.test.ts
+++ b/packages/provider-cloudflare/src/__tests__/codegen/generate-script.test.ts
@@ -424,3 +424,133 @@ describe('generateScript', () => {
     expect(code).toMatch(/interface Env \{[\s\S]*API_KEY: string;[\s\S]*\}/)
   })
 })
+
+describe('generateScript — annotation mode (@fetch / @queue)', () => {
+  const trivialIR = makeScript([stepNode('s', 'return { ok: true }')])
+
+  it('emits both fetch and queue handlers when @fetch and @queue are declared', () => {
+    const triggerCode = `
+@fetch function handler(request, env, ctx) {
+  return Response.json(await runGraph(env, { payload: {} }))
+}
+
+@queue function emails(batch, env, ctx) {
+  for (const msg of batch.messages) msg.ack()
+}
+`
+    const code = generateScript(trivialIR, { triggerCode })
+    expect(code).toContain('async fetch(request, env, ctx): Promise<Response>')
+    expect(code).toMatch(
+      /async queue\(batch: MessageBatch<unknown>, env: Env, ctx: ExecutionContext\): Promise<void>/,
+    )
+    expect(code).toContain('switch (batch.queue) {')
+    expect(code).toContain('case "emails":')
+    expect(code).toContain('msg.ack()')
+  })
+
+  it('emits multiple @queue handlers as switch cases', () => {
+    const triggerCode = `
+@fetch function handler(request, env, ctx) { return new Response("ok") }
+
+@queue function emails(batch, env, ctx) { /* email processing */ }
+@queue function jobs(batch, env, ctx) { /* job processing */ }
+`
+    const code = generateScript(trivialIR, { triggerCode })
+    expect(code).toContain('case "emails":')
+    expect(code).toContain('case "jobs":')
+    expect(code).toContain('email processing')
+    expect(code).toContain('job processing')
+  })
+
+  it('omits fetch handler entirely for queue-only workers', () => {
+    const triggerCode = `
+@queue function emails(batch, env, ctx) {
+  for (const msg of batch.messages) msg.ack()
+}
+`
+    const code = generateScript(trivialIR, { triggerCode })
+    expect(code).not.toContain('async fetch(')
+    expect(code).toContain('async queue(batch: MessageBatch<unknown>')
+    expect(code).toContain('case "emails":')
+  })
+
+  it('omits queue handler when no @queue annotations are present', () => {
+    const triggerCode = `
+@fetch function handler(request, env, ctx) {
+  return Response.json({ ok: true })
+}
+`
+    const code = generateScript(trivialIR, { triggerCode })
+    expect(code).toContain('async fetch(request, env, ctx)')
+    expect(code).not.toContain('async queue(')
+    expect(code).not.toContain('switch (batch.queue)')
+  })
+
+  it('emits module-level code outside annotated functions', () => {
+    const triggerCode = `
+const SHARED_CONFIG = { region: "eu" }
+function shared(x) { return x * 2 }
+
+@fetch function handler(request, env, ctx) {
+  return Response.json({ doubled: shared(21), config: SHARED_CONFIG })
+}
+`
+    const code = generateScript(trivialIR, { triggerCode })
+    expect(code).toContain('const SHARED_CONFIG = { region: "eu" }')
+    expect(code).toContain('function shared(x) { return x * 2 }')
+    // Module code emitted before runGraph so handlers can reference it.
+    const moduleIdx = code.indexOf('const SHARED_CONFIG')
+    const runGraphIdx = code.indexOf('async function runGraph')
+    expect(moduleIdx).toBeGreaterThan(0)
+    expect(moduleIdx).toBeLessThan(runGraphIdx)
+  })
+
+  it('hoists imports from inside any annotated handler body to module top', () => {
+    const triggerCode = `
+@fetch function handler(request, env, ctx) {
+  import puppeteer from "@cloudflare/puppeteer"
+  return Response.json({})
+}
+
+@queue function emails(batch, env, ctx) {
+  import { sendEmail } from "./email"
+  for (const msg of batch.messages) await sendEmail(msg.body)
+}
+`
+    const code = generateScript(trivialIR, { triggerCode })
+    // Imports should appear at the very top, NOT inside handler bodies.
+    const puppeteerImportIdx = code.indexOf('import puppeteer')
+    const fetchHandlerIdx = code.indexOf('async fetch(')
+    expect(puppeteerImportIdx).toBeGreaterThanOrEqual(0)
+    expect(puppeteerImportIdx).toBeLessThan(fetchHandlerIdx)
+
+    const sendEmailImportIdx = code.indexOf('import { sendEmail }')
+    expect(sendEmailImportIdx).toBeGreaterThanOrEqual(0)
+    expect(sendEmailImportIdx).toBeLessThan(fetchHandlerIdx)
+  })
+
+  it('preserves user param names from @fetch annotation', () => {
+    const triggerCode = `
+@fetch function handler(req, env, ctx) {
+  return new Response("hi from " + req.url)
+}
+`
+    const code = generateScript(trivialIR, { triggerCode })
+    // Use of 'req' (user's chosen name) is preserved, not rewritten to 'request'.
+    expect(code).toContain('async fetch(req, env, ctx)')
+    expect(code).toContain('req.url')
+  })
+
+  it('legacy mode emission unchanged when no annotations present', () => {
+    const code = generateScript(trivialIR)
+    expect(code).toContain('async fetch(request: Request, env: Env): Promise<Response>')
+    expect(code).not.toContain('async queue(')
+  })
+
+  it('throws AnnotationParseError on invalid @fetch name (propagates from parser)', () => {
+    const triggerCode = `@fetch function notHandler() { return new Response() }`
+    expect(() => generateScript(trivialIR, { triggerCode })).toThrow(
+      /requires function named 'handler'/,
+    )
+  })
+})

--- a/packages/provider-cloudflare/src/__tests__/codegen/generate-script.test.ts
+++ b/packages/provider-cloudflare/src/__tests__/codegen/generate-script.test.ts
@@ -38,7 +38,10 @@ describe('generateScript', () => {
     expect(code).not.toContain('WorkflowEntrypoint')
     expect(code).not.toContain('cloudflare:workers')
     expect(code).toContain('export default {')
-    expect(code).toContain('async fetch(request: Request, env: Env)')
+    // Default scaffolding uses the @fetch annotation form with user-supplied
+    // params (request, env, ctx). Legacy typed signature applies when a user
+    // overrides triggerCode without annotations.
+    expect(code).toContain('async fetch(request, env, ctx)')
   })
 
   it('isolates node code in a runGraph function', () => {
@@ -541,8 +544,13 @@ function shared(x) { return x * 2 }
     expect(code).toContain('req.url')
   })
 
-  it('legacy mode emission unchanged when no annotations present', () => {
-    const code = generateScript(trivialIR)
+  it('legacy mode emission used when triggerCode has no annotations', () => {
+    // When the user supplies a triggerCode that has no @fetch/@queue
+    // annotations (e.g. a raw try/catch body), legacy emission applies:
+    // typed `async fetch(request: Request, env: Env): Promise<Response>`.
+    const code = generateScript(trivialIR, {
+      triggerCode: 'try { return new Response("ok") } catch (e) { return Response.json({}) }',
+    })
     expect(code).toContain('async fetch(request: Request, env: Env): Promise<Response>')
     expect(code).not.toContain('async queue(')
   })

--- a/packages/provider-cloudflare/src/__tests__/codegen/generate.test.ts
+++ b/packages/provider-cloudflare/src/__tests__/codegen/generate.test.ts
@@ -23,6 +23,11 @@ describe('generateWorkflow', () => {
         WORKFLOW: Workflow;
       }
 
+      // import packages here
+
+      // Add queue handlers below using:
+      // @queue function NAME(batch, env, ctx) { ... }
+
       export class SimpleWorkflow extends WorkflowEntrypoint<Env> {
         async run(event, step) {
           const Fetch_data = await step.do("Fetch data", { retries: { limit: 3, delay: "5 seconds", backoff: "exponential" }, timeout: "30 seconds" }, async () => {
@@ -38,31 +43,30 @@ describe('generateWorkflow', () => {
       }
 
       export default {
-        async fetch(request: Request, env: Env): Promise<Response> {
-          try {
+        async fetch(request, env, ctx): Promise<Response> {
 
-          const url = new URL(request.url);
+            try {
+              const url = new URL(request.url);
 
-          if (request.method === "POST") {
-            const params = await request.json().catch(() => undefined);
-            const instance = await env.WORKFLOW.create({ params });
-            return Response.json({ instanceId: instance.id });
-          }
+              if (request.method === "POST") {
+                const params = await request.json().catch(() => undefined);
+                const instance = await env.WORKFLOW.create({ params });
+                return Response.json({ instanceId: instance.id });
+              }
 
-          const instanceId = url.searchParams.get("instanceId");
-          if (instanceId) {
-            const instance = await env.WORKFLOW.get(instanceId);
-            if (!instance) {
-              return Response.json({message: 'Instance not found'}, { status: 404 })
+              const instanceId = url.searchParams.get("instanceId");
+              if (instanceId) {
+                const instance = await env.WORKFLOW.get(instanceId);
+                if (!instance) {
+                  return Response.json({message: 'Instance not found'}, { status: 404 })
+                }
+                return Response.json(await instance.status());
+              }
+
+              return new Response(null, { status: 200 });
+            } catch (error) {
+              return Response.json({ message: error.message }, { status: 500 });
             }
-            return Response.json(await instance.status());
-          }
-
-          return new Response(null, { status: 200 });
-
-          } catch (error) {
-            return Response.json({ message: error.message }, { status: 500 });
-          }
 
         },
       };
@@ -114,7 +118,8 @@ describe('generateWorkflow', () => {
 
   it('generates functional fetch handler', () => {
     const code = generateWorkflow(simpleWorkflow as unknown as WorkflowIR)
-    expect(code).toContain('async fetch(request: Request, env: Env): Promise<Response>')
+    // Default scaffolding uses @fetch annotation form with user-supplied params.
+    expect(code).toContain('async fetch(request, env, ctx)')
     expect(code).toContain('request.method === "POST"')
     expect(code).toContain('env.WORKFLOW.create({ params })')
     expect(code).toContain('env.WORKFLOW.get(instanceId)')
@@ -353,8 +358,12 @@ function shared(x) { return x }
     expect(moduleIdx).toBeLessThan(classIdx)
   })
 
-  it('legacy mode emission unchanged when no annotations present', () => {
-    const code = generateWorkflow(ir)
+  it('legacy mode emission used when triggerCode has no annotations', () => {
+    // When user supplies a triggerCode that has no @fetch/@queue annotations,
+    // legacy emission applies: typed `async fetch(request: Request, env: Env)`.
+    const code = generateWorkflow(ir, {
+      triggerCode: 'try { return new Response("ok") } catch (e) { return Response.json({}) }',
+    })
     expect(code).toContain('async fetch(request: Request, env: Env): Promise<Response>')
     expect(code).not.toContain('async queue(')
   })

--- a/packages/provider-cloudflare/src/__tests__/codegen/generate.test.ts
+++ b/packages/provider-cloudflare/src/__tests__/codegen/generate.test.ts
@@ -296,3 +296,66 @@ describe('CloudflareCodeGenerator', () => {
     expect(gen.generateWorkflow(ir)).toBe(generateWorkflow(ir))
   })
 })
+
+describe('generateWorkflow — annotation mode (@fetch / @queue)', () => {
+  const ir = simpleWorkflow as unknown as WorkflowIR
+
+  it('emits both fetch and queue handlers when @fetch and @queue are declared', () => {
+    const triggerCode = `
+@fetch function handler(request, env, ctx) {
+  return Response.json({ status: "ok" })
+}
+
+@queue function emails(batch, env, ctx) {
+  for (const msg of batch.messages) msg.ack()
+}
+`
+    const code = generateWorkflow(ir, { triggerCode })
+    expect(code).toContain('async fetch(request, env, ctx): Promise<Response>')
+    expect(code).toMatch(
+      /async queue\(batch: MessageBatch<unknown>, env: Env, ctx: ExecutionContext\): Promise<void>/,
+    )
+    expect(code).toContain('switch (batch.queue) {')
+    expect(code).toContain('case "emails":')
+  })
+
+  it('omits fetch handler entirely for queue-only workers', () => {
+    const triggerCode = `
+@queue function jobs(batch, env, ctx) {
+  for (const msg of batch.messages) {
+    await env.WORKFLOW.create({ params: msg.body })
+    msg.ack()
+  }
+}
+`
+    const code = generateWorkflow(ir, { triggerCode })
+    expect(code).not.toContain('async fetch(')
+    expect(code).toContain('async queue(')
+    expect(code).toContain('case "jobs":')
+    expect(code).toContain('env.WORKFLOW.create')
+  })
+
+  it('emits module-level code outside annotated functions, before the WorkflowEntrypoint class', () => {
+    const triggerCode = `
+const REGION = "eu"
+function shared(x) { return x }
+
+@fetch function handler(request, env, ctx) {
+  return Response.json({ region: REGION })
+}
+`
+    const code = generateWorkflow(ir, { triggerCode })
+    expect(code).toContain('const REGION = "eu"')
+    expect(code).toContain('function shared(x) { return x }')
+    const moduleIdx = code.indexOf('const REGION')
+    const classIdx = code.indexOf('export class')
+    expect(moduleIdx).toBeGreaterThan(0)
+    expect(moduleIdx).toBeLessThan(classIdx)
+  })
+
+  it('legacy mode emission unchanged when no annotations present', () => {
+    const code = generateWorkflow(ir)
+    expect(code).toContain('async fetch(request: Request, env: Env): Promise<Response>')
+    expect(code).not.toContain('async queue(')
+  })
+})

--- a/packages/provider-cloudflare/src/__tests__/codegen/parse-annotations.test.ts
+++ b/packages/provider-cloudflare/src/__tests__/codegen/parse-annotations.test.ts
@@ -288,3 +288,106 @@ describe('parseAnnotations — unsupported annotations', () => {
     expect(() => parseAnnotations(source)).toThrow(/Unknown annotation '@scheduled'/)
   })
 })
+
+describe('parseAnnotations — @config block in @queue handler', () => {
+  it('parses a basic @config block and strips it from the body', () => {
+    const source = `@queue function emails(batch, env, ctx) {
+  @config {
+    max_batch_size: 25,
+    max_retries: 5
+  }
+  for (const msg of batch.messages) msg.ack()
+}`
+    const result = expectStrict(source)
+    const handler = result.queueHandlers[0]!
+    expect(handler.config).toEqual({ maxBatchSize: 25, maxRetries: 5 })
+    // @config block stripped from body
+    expect(handler.body).not.toContain('@config')
+    expect(handler.body).not.toContain('max_batch_size')
+    expect(handler.body).toContain('msg.ack()')
+  })
+
+  it('normalizes snake_case keys to camelCase', () => {
+    const source = `@queue function jobs(b, e, c) {
+  @config {
+    max_batch_size: 1,
+    max_batch_timeout: 30,
+    dead_letter_queue: "jobs-dlq",
+    max_concurrency: 5
+  }
+}`
+    const result = expectStrict(source)
+    expect(result.queueHandlers[0]!.config).toEqual({
+      maxBatchSize: 1,
+      maxBatchTimeout: 30,
+      deadLetterQueue: 'jobs-dlq',
+      maxConcurrency: 5,
+    })
+  })
+
+  it('coerces "5s" → 5 for numeric timeout fields', () => {
+    const source = `@queue function jobs(b, e, c) {
+  @config {
+    max_batch_timeout: "5s"
+  }
+}`
+    const result = expectStrict(source)
+    expect(result.queueHandlers[0]!.config).toEqual({ maxBatchTimeout: 5 })
+  })
+
+  it('coerces stringified numbers like "2"', () => {
+    const source = `@queue function jobs(b, e, c) {
+  @config { max_retries: "2" }
+}`
+    const result = expectStrict(source)
+    expect(result.queueHandlers[0]!.config).toEqual({ maxRetries: 2 })
+  })
+
+  it('queue handlers without @config get no config field', () => {
+    const source = `@queue function plain(b, e, c) {
+  msg.ack()
+}`
+    const result = expectStrict(source)
+    expect(result.queueHandlers[0]!.config).toBeUndefined()
+  })
+
+  it('rejects unknown @config keys', () => {
+    const source = `@queue function jobs(b, e, c) {
+  @config { batch_size: 25 }
+}`
+    expect(() => parseAnnotations(source)).toThrow(/unknown key 'batch_size'/)
+  })
+
+  it('rejects out-of-range values via schema validation', () => {
+    const source = `@queue function jobs(b, e, c) {
+  @config { max_batch_size: 200 }
+}`
+    expect(() => parseAnnotations(source)).toThrow(/@config validation failed/)
+  })
+
+  it('rejects @config not at the start of the queue body', () => {
+    const source = `@queue function jobs(b, e, c) {
+  msg.ack()
+  @config { max_batch_size: 5 }
+}`
+    expect(() => parseAnnotations(source)).toThrow(/must be at the start/)
+  })
+
+  it('rejects multiple @config blocks in the same handler', () => {
+    const source = `@queue function jobs(b, e, c) {
+  @config { max_batch_size: 5 }
+  @config { max_retries: 1 }
+}`
+    expect(() => parseAnnotations(source)).toThrow(/Duplicate @config/)
+  })
+
+  it('allows trailing comma in @config', () => {
+    const source = `@queue function jobs(b, e, c) {
+  @config {
+    max_batch_size: 5,
+  }
+}`
+    const result = expectStrict(source)
+    expect(result.queueHandlers[0]!.config).toEqual({ maxBatchSize: 5 })
+  })
+})

--- a/packages/provider-cloudflare/src/__tests__/codegen/parse-annotations.test.ts
+++ b/packages/provider-cloudflare/src/__tests__/codegen/parse-annotations.test.ts
@@ -1,0 +1,290 @@
+import { describe, it, expect } from 'vitest'
+import {
+  parseAnnotations,
+  AnnotationParseError,
+  type StrictParseResult,
+} from '../../codegen/parse-annotations.js'
+
+function expectStrict(source: string): StrictParseResult {
+  const result = parseAnnotations(source)
+  if (result.mode !== 'strict') throw new Error(`Expected strict mode, got ${result.mode}`)
+  return result
+}
+
+describe('parseAnnotations — legacy mode', () => {
+  it('returns legacy mode when no annotations present', () => {
+    const source = `try { return new Response("ok") } catch (e) { return Response.json({}) }`
+    const result = parseAnnotations(source)
+    expect(result.mode).toBe('legacy')
+    if (result.mode === 'legacy') {
+      expect(result.fetchBody).toBe(source)
+    }
+  })
+
+  it('treats @ inside string literal as legacy code (no annotations)', () => {
+    const source = `const email = "user@example.com"; return Response.json({ email })`
+    const result = parseAnnotations(source)
+    expect(result.mode).toBe('legacy')
+  })
+
+  it('treats annotation-shaped text in JSDoc as legacy code', () => {
+    const source = `
+/**
+ * Example:
+ * @queue function emails() { ... }
+ */
+return Response.json({})
+`
+    const result = parseAnnotations(source)
+    expect(result.mode).toBe('legacy')
+  })
+
+  it('treats annotation-shaped text in template literal as legacy code', () => {
+    const source = 'const docs = `\n  @queue function emails(){}\n`\nreturn Response.json({ docs })'
+    const result = parseAnnotations(source)
+    expect(result.mode).toBe('legacy')
+  })
+
+  it('treats annotation-shaped text in line comment as legacy code', () => {
+    const source = `// @queue function emails() {}
+return Response.json({})`
+    const result = parseAnnotations(source)
+    expect(result.mode).toBe('legacy')
+  })
+})
+
+describe('parseAnnotations — strict mode @fetch', () => {
+  it('extracts a single @fetch handler', () => {
+    const source = `@fetch function handler(request, env, ctx) {
+  return new Response("ok")
+}`
+    const result = expectStrict(source)
+    expect(result.fetchHandler).toBeDefined()
+    expect(result.fetchHandler?.name).toBe('handler')
+    expect(result.fetchHandler?.params).toBe('request, env, ctx')
+    expect(result.fetchHandler?.body.trim()).toBe('return new Response("ok")')
+    expect(result.queueHandlers).toHaveLength(0)
+  })
+
+  it('rejects @fetch with non-handler name', () => {
+    const source = `@fetch function notHandler() { return new Response() }`
+    expect(() => parseAnnotations(source)).toThrow(AnnotationParseError)
+    expect(() => parseAnnotations(source)).toThrow(/requires function named 'handler'/)
+  })
+
+  it('rejects multiple @fetch handlers', () => {
+    const source = `
+@fetch function handler() { return new Response("a") }
+@fetch function handler() { return new Response("b") }
+`
+    expect(() => parseAnnotations(source)).toThrow(/Multiple @fetch handlers/)
+  })
+})
+
+describe('parseAnnotations — strict mode @queue', () => {
+  it('extracts a single @queue handler', () => {
+    const source = `@queue function emails(batch, env, ctx) {
+  for (const msg of batch.messages) msg.ack()
+}`
+    const result = expectStrict(source)
+    expect(result.fetchHandler).toBeUndefined()
+    expect(result.queueHandlers).toHaveLength(1)
+    expect(result.queueHandlers[0]!.name).toBe('emails')
+    expect(result.queueHandlers[0]!.params).toBe('batch, env, ctx')
+    expect(result.queueHandlers[0]!.body).toContain('msg.ack()')
+  })
+
+  it('extracts multiple @queue handlers with different names', () => {
+    const source = `
+@queue function emails(batch, env, ctx) { /* a */ }
+@queue function jobs(batch, env, ctx) { /* b */ }
+@queue function analytics(batch, env, ctx) { /* c */ }
+`
+    const result = expectStrict(source)
+    expect(result.queueHandlers.map((h) => h.name)).toEqual(['emails', 'jobs', 'analytics'])
+  })
+
+  it('rejects duplicate @queue names', () => {
+    const source = `
+@queue function emails(b, e, c) {}
+@queue function emails(b, e, c) {}
+`
+    expect(() => parseAnnotations(source)).toThrow(/Duplicate queue handler 'emails'/)
+  })
+})
+
+describe('parseAnnotations — combined handlers', () => {
+  it('extracts both @fetch and @queue', () => {
+    const source = `
+import puppeteer from "@cloudflare/puppeteer"
+
+@fetch function handler(request, env, ctx) {
+  return Response.json({})
+}
+
+@queue function emails(batch, env, ctx) {
+  for (const msg of batch.messages) msg.ack()
+}
+`
+    const result = expectStrict(source)
+    expect(result.fetchHandler?.body).toContain('Response.json')
+    expect(result.queueHandlers).toHaveLength(1)
+    expect(result.queueHandlers[0]!.name).toBe('emails')
+    expect(result.moduleCode).toContain('import puppeteer')
+  })
+
+  it('strips annotated functions from moduleCode but keeps top-level code', () => {
+    const source = `import puppeteer from "@cloudflare/puppeteer"
+const SHARED = 42
+
+@fetch function handler(request, env, ctx) {
+  return Response.json({ SHARED })
+}
+
+function helper() { return 'help' }`
+    const result = expectStrict(source)
+    expect(result.moduleCode).toContain('import puppeteer')
+    expect(result.moduleCode).toContain('const SHARED = 42')
+    expect(result.moduleCode).toContain('function helper()')
+    expect(result.moduleCode).not.toContain('@fetch')
+    expect(result.moduleCode).not.toContain('return Response.json({ SHARED })')
+  })
+
+  it('preserves line numbers when stripping', () => {
+    const source = `// line 1
+@fetch function handler() {
+  return new Response()
+}
+// line 5
+return moduleCode`
+    const result = expectStrict(source)
+    // The stripped function spans lines 2-4. Module code should keep the same
+    // total line count (newlines preserved).
+    expect(result.moduleCode.split('\n')).toHaveLength(source.split('\n').length)
+  })
+})
+
+describe('parseAnnotations — handler bodies with nested constructs', () => {
+  it('handles function bodies with nested braces', () => {
+    const source = `@queue function emails(batch, env, ctx) {
+  for (const msg of batch.messages) {
+    if (msg.body) {
+      try {
+        msg.ack()
+      } catch (e) {
+        console.error(e)
+      }
+    }
+  }
+}`
+    const result = expectStrict(source)
+    expect(result.queueHandlers[0]!.body).toContain('try {')
+    expect(result.queueHandlers[0]!.body).toContain('console.error(e)')
+  })
+
+  it('handles bodies with strings containing braces', () => {
+    const source = `@queue function emails(b, e, c) {
+  const msg = "} not a closing brace"
+  return msg
+}`
+    const result = expectStrict(source)
+    expect(result.queueHandlers[0]!.body).toContain('"} not a closing brace"')
+  })
+
+  it('handles bodies with template literals containing braces', () => {
+    const source = `@queue function emails(b, e, c) {
+  const msg = \`hello \${name}\`
+  return msg
+}`
+    const result = expectStrict(source)
+    expect(result.queueHandlers[0]!.body).toContain('${name}')
+  })
+
+  it('handles bodies with line comments containing braces', () => {
+    const source = `@queue function emails(b, e, c) {
+  // braces in comment }
+  return null
+}`
+    const result = expectStrict(source)
+    expect(result.queueHandlers[0]!.body).toContain('// braces in comment }')
+    expect(result.queueHandlers[0]!.body).toContain('return null')
+  })
+
+  it('handles bodies with block comments containing braces', () => {
+    const source = `@queue function emails(b, e, c) {
+  /* nested } } } braces */
+  return null
+}`
+    const result = expectStrict(source)
+    expect(result.queueHandlers[0]!.body).toContain('/* nested } } } braces */')
+  })
+})
+
+describe('parseAnnotations — placement validation', () => {
+  it('rejects @queue annotation inside a function body', () => {
+    const source = `@fetch function handler(request, env, ctx) {
+  @queue function emails(b, e, c) {}
+  return Response.json({})
+}`
+    expect(() => parseAnnotations(source)).toThrow(/must be declared at top level/)
+  })
+
+  it('rejects @queue annotation inside a try/catch block', () => {
+    const source = `try {
+  @queue function emails(b, e, c) {}
+} catch (e) {}`
+    expect(() => parseAnnotations(source)).toThrow(/must be declared at top level/)
+  })
+})
+
+describe('parseAnnotations — entry-point validation', () => {
+  it('rejects strict mode with no handlers (annotation but unsupported kind)', () => {
+    // Only one annotation, and it's invalid kind — gets rejected before "no entry point".
+    const source = `@scheduled function cron(event, env, ctx) {}`
+    expect(() => parseAnnotations(source)).toThrow(/Unknown annotation '@scheduled'/)
+  })
+
+  it('queue-only worker is valid (no @fetch required)', () => {
+    const source = `@queue function emails(batch, env, ctx) {
+  for (const msg of batch.messages) msg.ack()
+}`
+    const result = expectStrict(source)
+    expect(result.fetchHandler).toBeUndefined()
+    expect(result.queueHandlers).toHaveLength(1)
+  })
+})
+
+describe('parseAnnotations — error messages include line numbers', () => {
+  it('reports the line of the offending @fetch with wrong name', () => {
+    const source = `// line 1
+// line 2
+@fetch function notHandler() {}`
+    try {
+      parseAnnotations(source)
+      throw new Error('expected throw')
+    } catch (err) {
+      expect(err).toBeInstanceOf(AnnotationParseError)
+      expect((err as AnnotationParseError).line).toBe(3)
+    }
+  })
+
+  it('reports the line of the duplicate @queue', () => {
+    const source = `@queue function emails(b, e, c) {}
+
+@queue function emails(b, e, c) {}`
+    try {
+      parseAnnotations(source)
+      throw new Error('expected throw')
+    } catch (err) {
+      expect(err).toBeInstanceOf(AnnotationParseError)
+      expect((err as AnnotationParseError).line).toBe(3)
+    }
+  })
+})
+
+describe('parseAnnotations — unsupported annotations', () => {
+  it('rejects unknown annotation kinds', () => {
+    const source = `@scheduled function cron(event, env, ctx) {}`
+    expect(() => parseAnnotations(source)).toThrow(/Unknown annotation '@scheduled'/)
+  })
+})

--- a/packages/provider-cloudflare/src/__tests__/config-schema.test.ts
+++ b/packages/provider-cloudflare/src/__tests__/config-schema.test.ts
@@ -45,6 +45,63 @@ describe('cloudflareDeploymentConfigSchema', () => {
   })
 })
 
+describe('cloudflareDeploymentConfigSchema — queueConsumers', () => {
+  it('accepts a valid queueConsumers array', () => {
+    const parsed = cloudflareDeploymentConfigSchema.safeParse({
+      queueConsumers: [
+        {
+          queue: 'emails',
+          maxBatchSize: 25,
+          maxBatchTimeout: 30,
+          maxRetries: 3,
+          deadLetterQueue: 'emails-dlq',
+          maxConcurrency: 5,
+        },
+      ],
+    })
+    expect(parsed.success).toBe(true)
+  })
+
+  it('accepts an entry with only the queue name (defaults applied at wrangler emission)', () => {
+    const parsed = cloudflareDeploymentConfigSchema.safeParse({
+      queueConsumers: [{ queue: 'jobs' }],
+    })
+    expect(parsed.success).toBe(true)
+  })
+
+  it('rejects empty queue name', () => {
+    const parsed = cloudflareDeploymentConfigSchema.safeParse({
+      queueConsumers: [{ queue: '' }],
+    })
+    expect(parsed.success).toBe(false)
+  })
+
+  it('rejects out-of-range maxBatchSize', () => {
+    const tooBig = cloudflareDeploymentConfigSchema.safeParse({
+      queueConsumers: [{ queue: 'jobs', maxBatchSize: 101 }],
+    })
+    const tooSmall = cloudflareDeploymentConfigSchema.safeParse({
+      queueConsumers: [{ queue: 'jobs', maxBatchSize: 0 }],
+    })
+    expect(tooBig.success).toBe(false)
+    expect(tooSmall.success).toBe(false)
+  })
+
+  it('rejects out-of-range maxConcurrency (CF caps at 20)', () => {
+    const parsed = cloudflareDeploymentConfigSchema.safeParse({
+      queueConsumers: [{ queue: 'jobs', maxConcurrency: 21 }],
+    })
+    expect(parsed.success).toBe(false)
+  })
+
+  it('rejects unknown keys inside a queue consumer entry', () => {
+    const parsed = cloudflareDeploymentConfigSchema.safeParse({
+      queueConsumers: [{ queue: 'jobs', unknownField: true }],
+    })
+    expect(parsed.success).toBe(false)
+  })
+})
+
 describe('cloudflareDefaultDeploymentConfig', () => {
   it('validates against its own schema', () => {
     expect(

--- a/packages/provider-cloudflare/src/__tests__/wrangler-config.test.ts
+++ b/packages/provider-cloudflare/src/__tests__/wrangler-config.test.ts
@@ -451,4 +451,70 @@ describe('generateWranglerConfig', () => {
       } as Parameters<typeof generateWranglerConfig>[0]),
     ).toThrow(/workflow deploys require/)
   })
+
+  describe('queueConsumers', () => {
+    const baseScript = {
+      kind: 'script' as const,
+      workerName: 'awaitstep-q',
+      main: './worker.js',
+    }
+
+    it('emits queues.consumers when queueConsumers provided', () => {
+      const json = generateWranglerConfig({
+        ...baseScript,
+        queueConsumers: [
+          {
+            queue: 'emails',
+            maxBatchSize: 25,
+            maxBatchTimeout: 30,
+            maxRetries: 5,
+            deadLetterQueue: 'emails-dlq',
+            maxConcurrency: 10,
+          },
+        ],
+      })
+      const parsed = JSON.parse(json)
+      expect(parsed.queues.consumers).toEqual([
+        {
+          queue: 'emails',
+          max_batch_size: 25,
+          max_batch_timeout: 30,
+          max_retries: 5,
+          dead_letter_queue: 'emails-dlq',
+          max_concurrency: 10,
+        },
+      ])
+    })
+
+    it('emits a minimal consumer entry when only queue name is provided', () => {
+      const json = generateWranglerConfig({
+        ...baseScript,
+        queueConsumers: [{ queue: 'jobs' }],
+      })
+      const parsed = JSON.parse(json)
+      expect(parsed.queues.consumers).toEqual([{ queue: 'jobs' }])
+    })
+
+    it('coexists with queues.producers in the same queues object', () => {
+      const json = generateWranglerConfig({
+        ...baseScript,
+        bindings: [
+          { name: 'QUEUE_EMAILS', type: 'queue', source: 'code-scan', resourceId: 'emails' },
+        ],
+        queueConsumers: [{ queue: 'emails' }],
+      })
+      const parsed = JSON.parse(json)
+      expect(parsed.queues.producers).toEqual([{ binding: 'QUEUE_EMAILS', queue: 'emails' }])
+      expect(parsed.queues.consumers).toEqual([{ queue: 'emails' }])
+    })
+
+    it('omits queues.consumers entirely when queueConsumers is empty', () => {
+      const json = generateWranglerConfig({
+        ...baseScript,
+        queueConsumers: [],
+      })
+      const parsed = JSON.parse(json)
+      expect(parsed.queues).toBeUndefined()
+    })
+  })
 })

--- a/packages/provider-cloudflare/src/__tests__/wrangler-config.test.ts
+++ b/packages/provider-cloudflare/src/__tests__/wrangler-config.test.ts
@@ -112,7 +112,7 @@ describe('generateWranglerConfig', () => {
     })
 
     const parsed = JSON.parse(config)
-    expect(parsed.queues).toEqual({ producers: [{ binding: 'QUEUE_JOBS', queue: 'queue_jobs' }] })
+    expect(parsed.queues).toEqual({ producers: [{ binding: 'QUEUE_JOBS', queue: 'jobs' }] })
   })
 
   it('includes service bindings', () => {
@@ -506,6 +506,32 @@ describe('generateWranglerConfig', () => {
       const parsed = JSON.parse(json)
       expect(parsed.queues.producers).toEqual([{ binding: 'QUEUE_EMAILS', queue: 'emails' }])
       expect(parsed.queues.consumers).toEqual([{ queue: 'emails' }])
+    })
+
+    it('producer queue name strips QUEUE_ prefix so it matches @queue annotation default', () => {
+      // No resourceId override: producer derives the queue name from the binding
+      // name. Must align with deriveQueueName() so that `env.QUEUE_EMAILS.send(...)`
+      // and `@queue function emails(...)` end up wired to the same queue.
+      const json = generateWranglerConfig({
+        ...baseScript,
+        bindings: [{ name: 'QUEUE_EMAILS', type: 'queue', source: 'code-scan' }],
+        queueConsumers: [{ queue: 'emails' }],
+      })
+      const parsed = JSON.parse(json)
+      expect(parsed.queues.producers).toEqual([{ binding: 'QUEUE_EMAILS', queue: 'emails' }])
+      expect(parsed.queues.consumers).toEqual([{ queue: 'emails' }])
+    })
+
+    it('producer respects resourceId override when provided', () => {
+      // Backwards-compat path: explicit override wins over the derived default.
+      const json = generateWranglerConfig({
+        ...baseScript,
+        bindings: [
+          { name: 'QUEUE_LEGACY', type: 'queue', source: 'code-scan', resourceId: 'queue_legacy' },
+        ],
+      })
+      const parsed = JSON.parse(json)
+      expect(parsed.queues.producers).toEqual([{ binding: 'QUEUE_LEGACY', queue: 'queue_legacy' }])
     })
 
     it('omits queues.consumers entirely when queueConsumers is empty', () => {

--- a/packages/provider-cloudflare/src/adapter.ts
+++ b/packages/provider-cloudflare/src/adapter.ts
@@ -470,15 +470,18 @@ function extractCredentials(config: ProviderConfig): {
 
 /**
  * Returns the queue-consumer wiring for wrangler.json based on `@queue function NAME(...)`
- * annotations in the trigger code, merged with per-queue settings from
- * `deploymentConfig.queueConsumers`.
+ * annotations in the trigger code, merged with per-queue settings.
  *
- * - Each `@queue function NAME(...)` declaration produces one consumer entry.
- * - If `deploymentConfig.queueConsumers` has an entry for a given queue name,
- *   its batch/retry/concurrency/DLQ settings are applied. Otherwise CF defaults
- *   apply at runtime (max_batch_size: 10, max_batch_timeout: 5s, max_retries: 3).
- * - Returns `undefined` when there are no `@queue` declarations (no consumer
- *   block emitted in wrangler.json).
+ * Settings merge in priority order (highest wins):
+ *   1. `deploymentConfig.queueConsumers` — per-environment override from the
+ *      deployment config (lets dev/staging/prod tune independently).
+ *   2. The handler's inline `@config { ... }` block — the source-co-located
+ *      default for the queue.
+ *   3. CF defaults (no field) — `max_batch_size: 10`, `max_batch_timeout: 5s`,
+ *      `max_retries: 3`.
+ *
+ * Returns `undefined` when there are no `@queue` declarations (no consumer
+ * block emitted in wrangler.json).
  *
  * Annotation parse errors are silently swallowed here — they're already
  * surfaced as a structured DeployResult by the codegen path that runs first
@@ -498,11 +501,11 @@ export function buildQueueConsumers(
     }>
   | undefined {
   if (!triggerCode) return undefined
-  let queueNames: string[]
+  let handlers: Array<{ name: string; config?: Record<string, string | number | boolean> }>
   try {
     const parsed = parseAnnotations(triggerCode)
     if (parsed.mode !== 'strict' || parsed.queueHandlers.length === 0) return undefined
-    queueNames = parsed.queueHandlers.map((q) => q.name)
+    handlers = parsed.queueHandlers.map((q) => ({ name: q.name, config: q.config }))
   } catch {
     return undefined
   }
@@ -510,16 +513,28 @@ export function buildQueueConsumers(
   const overrides = new Map(
     (deploymentConfig?.queueConsumers ?? []).map((c) => [c.queue, c] as const),
   )
-  return queueNames.map((name) => {
-    const o = overrides.get(name)
-    if (!o) return { queue: name }
-    return {
-      queue: name,
-      ...(o.maxBatchSize !== undefined && { maxBatchSize: o.maxBatchSize }),
-      ...(o.maxBatchTimeout !== undefined && { maxBatchTimeout: o.maxBatchTimeout }),
-      ...(o.maxRetries !== undefined && { maxRetries: o.maxRetries }),
-      ...(o.deadLetterQueue !== undefined && { deadLetterQueue: o.deadLetterQueue }),
-      ...(o.maxConcurrency !== undefined && { maxConcurrency: o.maxConcurrency }),
+  return handlers.map(({ name, config }) => {
+    const override = overrides.get(name)
+    const merged: Record<string, unknown> = { queue: name }
+    // Layer (2): inline @config block.
+    if (config) {
+      for (const [k, v] of Object.entries(config)) merged[k] = v
+    }
+    // Layer (1): deploymentConfig override (highest priority).
+    if (override) {
+      if (override.maxBatchSize !== undefined) merged.maxBatchSize = override.maxBatchSize
+      if (override.maxBatchTimeout !== undefined) merged.maxBatchTimeout = override.maxBatchTimeout
+      if (override.maxRetries !== undefined) merged.maxRetries = override.maxRetries
+      if (override.deadLetterQueue !== undefined) merged.deadLetterQueue = override.deadLetterQueue
+      if (override.maxConcurrency !== undefined) merged.maxConcurrency = override.maxConcurrency
+    }
+    return merged as {
+      queue: string
+      maxBatchSize?: number
+      maxBatchTimeout?: number
+      maxRetries?: number
+      deadLetterQueue?: string
+      maxConcurrency?: number
     }
   })
 }

--- a/packages/provider-cloudflare/src/adapter.ts
+++ b/packages/provider-cloudflare/src/adapter.ts
@@ -23,6 +23,7 @@ import { CloudflareAPI } from './api.js'
 import { WRANGLER_BASE_CONFIG } from './wrangler-config.js'
 import { detectBindings, type BindingRequirement } from './codegen/bindings.js'
 import { getSubWorkflowBindings } from './codegen/generators/sub-workflow.js'
+import { parseAnnotations } from './codegen/parse-annotations.js'
 import {
   cloudflareDefaultDeploymentConfig,
   cloudflareDeploymentConfigSchema,
@@ -320,6 +321,13 @@ export class CloudflareWorkflowsAdapter implements WorkflowProvider, LocalDevPro
     const workersDev =
       deploymentConfig?.workersDev ?? (config.options?.['workersDev'] as boolean | undefined)
 
+    // Build queue consumer wiring from `@queue function NAME(...)` annotations in
+    // the trigger code. Each consumed queue gets one row in wrangler.json's
+    // `queues.consumers[]`. Per-queue settings come from
+    // `deploymentConfig.queueConsumers` if present; otherwise CF defaults apply.
+    const triggerCodeForAnnotations = config.options?.['triggerCode'] as string | undefined
+    const queueConsumers = buildQueueConsumers(triggerCodeForAnnotations, deploymentConfig)
+
     if (!this.deployer) {
       report('FAILED', 'No deployer configured — deploy is not available on this runtime', 0)
       return { success: false, deploymentId: '', error: 'No deployer configured' }
@@ -357,6 +365,7 @@ export class CloudflareWorkflowsAdapter implements WorkflowProvider, LocalDevPro
         limits: deploymentConfig?.limits,
         observability: deploymentConfig?.observability,
         logpush: deploymentConfig?.logpush,
+        queueConsumers,
       },
       deployerProgress,
     )
@@ -457,6 +466,62 @@ function extractCredentials(config: ProviderConfig): {
     throw new Error('accountId and apiToken are required in credentials')
   }
   return { accountId, apiToken }
+}
+
+/**
+ * Returns the queue-consumer wiring for wrangler.json based on `@queue function NAME(...)`
+ * annotations in the trigger code, merged with per-queue settings from
+ * `deploymentConfig.queueConsumers`.
+ *
+ * - Each `@queue function NAME(...)` declaration produces one consumer entry.
+ * - If `deploymentConfig.queueConsumers` has an entry for a given queue name,
+ *   its batch/retry/concurrency/DLQ settings are applied. Otherwise CF defaults
+ *   apply at runtime (max_batch_size: 10, max_batch_timeout: 5s, max_retries: 3).
+ * - Returns `undefined` when there are no `@queue` declarations (no consumer
+ *   block emitted in wrangler.json).
+ *
+ * Annotation parse errors are silently swallowed here — they're already
+ * surfaced as a structured DeployResult by the codegen path that runs first
+ * (see `generate()` above).
+ */
+export function buildQueueConsumers(
+  triggerCode: string | undefined,
+  deploymentConfig: CloudflareDeploymentConfig | undefined,
+):
+  | Array<{
+      queue: string
+      maxBatchSize?: number
+      maxBatchTimeout?: number
+      maxRetries?: number
+      deadLetterQueue?: string
+      maxConcurrency?: number
+    }>
+  | undefined {
+  if (!triggerCode) return undefined
+  let queueNames: string[]
+  try {
+    const parsed = parseAnnotations(triggerCode)
+    if (parsed.mode !== 'strict' || parsed.queueHandlers.length === 0) return undefined
+    queueNames = parsed.queueHandlers.map((q) => q.name)
+  } catch {
+    return undefined
+  }
+
+  const overrides = new Map(
+    (deploymentConfig?.queueConsumers ?? []).map((c) => [c.queue, c] as const),
+  )
+  return queueNames.map((name) => {
+    const o = overrides.get(name)
+    if (!o) return { queue: name }
+    return {
+      queue: name,
+      ...(o.maxBatchSize !== undefined && { maxBatchSize: o.maxBatchSize }),
+      ...(o.maxBatchTimeout !== undefined && { maxBatchTimeout: o.maxBatchTimeout }),
+      ...(o.maxRetries !== undefined && { maxRetries: o.maxRetries }),
+      ...(o.deadLetterQueue !== undefined && { deadLetterQueue: o.deadLetterQueue }),
+      ...(o.maxConcurrency !== undefined && { maxConcurrency: o.maxConcurrency }),
+    }
+  })
 }
 
 export function mapCFStatus(cfStatus: string): WorkflowStatus {

--- a/packages/provider-cloudflare/src/codegen/bindings.ts
+++ b/packages/provider-cloudflare/src/codegen/bindings.ts
@@ -22,6 +22,23 @@ export interface BindingRequirement {
   resourceId?: string
 }
 
+/**
+ * Derives the canonical queue name from a `QUEUE_*` binding identifier.
+ *
+ * - `QUEUE_EMAILS` → `emails`
+ * - `QUEUE_JOBS` → `jobs`
+ * - bare `QUEUE` → `queue`
+ *
+ * Used in two places that MUST agree, otherwise producer and consumer end
+ * up wired to different CF queues:
+ * - `generateWranglerConfig` producer derivation (`queues.producers[].queue`)
+ * - `@queue function NAME(...)` annotation suggestion in the bindings panel
+ */
+export function deriveQueueName(bindingName: string): string {
+  const stripped = bindingName.replace(/^QUEUE_?/i, '')
+  return (stripped || bindingName).toLowerCase()
+}
+
 const BINDING_PATTERNS: Array<{ pattern: RegExp; type: BindingType }> = [
   { pattern: /env\.(KV\w*)/g, type: 'kv' },
   { pattern: /env\.(DB\w*)/g, type: 'd1' },

--- a/packages/provider-cloudflare/src/codegen/generate-helpers.ts
+++ b/packages/provider-cloudflare/src/codegen/generate-helpers.ts
@@ -37,6 +37,38 @@ export const CF_ENV_TYPE: Record<BindingType, string | null> = {
 }
 
 /**
+ * Collapses runs of blank/whitespace-only lines in source so the generated
+ * worker doesn't carry the empty whitespace left behind by the annotation
+ * parser when it strips `@kind function NAME(...) { ... }` blocks (the
+ * stripper replaces those spans with spaces to preserve line numbers).
+ */
+export function collapseBlankLines(source: string): string {
+  return source.replace(/\n(?:[ \t]*\n){2,}/g, '\n\n')
+}
+
+/**
+ * Returns true if the body's last non-empty line is a `return` statement
+ * (with or without value, with or without trailing semicolon). Used to
+ * suppress redundant trailing returns appended by the codegen when the user's
+ * code already exits explicitly.
+ *
+ * Heuristic: walks the body backwards to find the last non-blank line, strips
+ * trailing semicolons, and matches `^return\b`. Doesn't reason about nested
+ * blocks (an `if (x) { return }` with no else is correctly NOT detected as
+ * always-returning, so the safety-net trailing return remains).
+ */
+export function endsWithReturn(body: string): boolean {
+  const lines = body.split('\n')
+  for (let i = lines.length - 1; i >= 0; i--) {
+    const line = lines[i]!.trim()
+    if (line === '') continue
+    const stripped = line.replace(/;+\s*$/, '').trim()
+    return /^return\b/.test(stripped)
+  }
+  return false
+}
+
+/**
  * Splits `import` statements (single- or multi-line) from the rest of a code
  * block. Used to hoist user-trigger-code imports to the top of the generated
  * Worker file alongside imports from per-node generators.

--- a/packages/provider-cloudflare/src/codegen/generate-script.ts
+++ b/packages/provider-cloudflare/src/codegen/generate-script.ts
@@ -20,6 +20,7 @@ import {
   generateNodeCode,
   resolveNodeExpressions,
 } from './generate-helpers.js'
+import { parseAnnotations } from './parse-annotations.js'
 
 /**
  * Default body of the fetch handler for scripts. The graph nodes run inside
@@ -228,8 +229,38 @@ export function generateScript(
 
   const rawTriggerCode =
     triggerCode && triggerCode.length > 0 ? triggerCode : DEFAULT_SCRIPT_TRIGGER_CODE
-  const { imports: triggerImports, body: fetchBody } = extractImports(rawTriggerCode)
-  collectedImports.push(...triggerImports)
+
+  const parsed = parseAnnotations(rawTriggerCode)
+
+  // Per-block import extraction. In legacy mode there's only one block (the
+  // fetch body). In strict mode we extract imports from module-level code,
+  // the @fetch handler body, and every @queue handler body — all imports get
+  // hoisted to the top of the generated worker.
+  let moduleCode = ''
+  let fetchHandlerEmission: { params: string; body: string } | null = null
+  const queueHandlerEmissions: Array<{ name: string; params: string; body: string }> = []
+
+  if (parsed.mode === 'legacy') {
+    const { imports, body } = extractImports(parsed.fetchBody)
+    collectedImports.push(...imports)
+    fetchHandlerEmission = { params: 'request: Request, env: Env', body }
+  } else {
+    if (parsed.moduleCode.trim().length > 0) {
+      const { imports, body } = extractImports(parsed.moduleCode)
+      collectedImports.push(...imports)
+      moduleCode = body
+    }
+    if (parsed.fetchHandler) {
+      const { imports, body } = extractImports(parsed.fetchHandler.body)
+      collectedImports.push(...imports)
+      fetchHandlerEmission = { params: parsed.fetchHandler.params, body }
+    }
+    for (const qh of parsed.queueHandlers) {
+      const { imports, body } = extractImports(qh.body)
+      collectedImports.push(...imports)
+      queueHandlerEmissions.push({ name: qh.name, params: qh.params, body })
+    }
+  }
 
   // runGraph isolates node-emitted code in its own function. Only nodes
   // marked for export (display name prefixed with `EXPORT_`) surface on
@@ -248,16 +279,40 @@ ${declStatement}${graphBody.trim().length > 0 ? indent(graphBody, 2) + '\n' : ''
     !preview && classDefinitions.size > 0
       ? '\n' + [...classDefinitions.values()].join('\n\n') + '\n'
       : ''
+  const moduleCodeBlock = moduleCode.trim().length > 0 ? '\n' + moduleCode.trim() + '\n' : ''
   const envBlock = envFields.length > 0 ? `\n${envFields.join('\n')}\n` : ''
 
+  // Build the export default object — fetch handler is omitted entirely for
+  // queue-only workers; queue handler is omitted when no @queue annotations.
+  const handlerBlocks: string[] = []
+  if (fetchHandlerEmission) {
+    handlerBlocks.push(`  async fetch(${fetchHandlerEmission.params}): Promise<Response> {
+${indent(fetchHandlerEmission.body, 4)}
+  },`)
+  }
+  if (queueHandlerEmissions.length > 0) {
+    const cases = queueHandlerEmissions
+      .map(
+        (qh) => `      case "${qh.name}": {
+${indent(qh.body, 8)}
+        return
+      }`,
+      )
+      .join('\n')
+    handlerBlocks.push(`  async queue(batch: MessageBatch<unknown>, env: Env, ctx: ExecutionContext): Promise<void> {
+    switch (batch.queue) {
+${cases}
+    }
+  },`)
+  }
+  const exportDefault = `export default {
+${handlerBlocks.join('\n')}
+};`
+
   return `${importBlock ? importBlock.trimStart() + '\n\n' : ''}interface Env {${envBlock}}
-${classBlock}
+${classBlock}${moduleCodeBlock}
 ${runGraphBlock}
 
-export default {
-  async fetch(request: Request, env: Env): Promise<Response> {
-${indent(fetchBody, 4)}
-  },
-};
+${exportDefault}
 `
 }

--- a/packages/provider-cloudflare/src/codegen/generate-script.ts
+++ b/packages/provider-cloudflare/src/codegen/generate-script.ts
@@ -16,6 +16,8 @@ import { hasTemplateExpressions } from './generators/state-tracking.js'
 import { detectBindings } from './bindings.js'
 import {
   CF_ENV_TYPE,
+  collapseBlankLines,
+  endsWithReturn,
   extractImports,
   generateNodeCode,
   resolveNodeExpressions,
@@ -23,28 +25,39 @@ import {
 import { parseAnnotations } from './parse-annotations.js'
 
 /**
- * Default body of the fetch handler for scripts. The graph nodes run inside
- * `runGraph(env, event)` (auto-generated, isolated), and this body decides
- * what to do with their outputs. Users can replace this code via the script's
- * `triggerCode` field — the runGraph call and the `graph.*` outputs stay
- * stable across edits.
+ * Default trigger-code scaffold for new scripts. Uses the annotated multi-handler
+ * form: `@fetch function handler(...)` for the HTTP entry point, with a comment
+ * showing how to add `@queue function NAME(...)` handlers.
+ *
+ * Top-level code outside annotated functions becomes module scope (imports,
+ * shared helpers). The graph nodes run inside `runGraph(env, event)` (auto-
+ * generated, isolated); the @fetch handler decides what to do with their
+ * outputs. Users can replace this code via the script's `triggerCode` field —
+ * the runGraph call and `graph.*` outputs stay stable across edits.
  */
-export const DEFAULT_SCRIPT_TRIGGER_CODE = `try {
-  if (request.method !== "POST") {
-    return new Response(null, { status: 200 });
+export const DEFAULT_SCRIPT_TRIGGER_CODE = `// import packages here
+
+@fetch function handler(request, env, ctx) {
+  try {
+    if (request.method !== "POST") {
+      return new Response(null, { status: 200 });
+    }
+    const params = await request.json().catch(() => undefined);
+    const event = { payload: params };
+
+    const graph = await runGraph(env, event);
+
+    // ▼ everything below is yours — change the response, add error
+    // handling, branch on request shape, etc. Available outputs are on
+    // \`graph.*\` (one entry per step that returns a value).
+    return Response.json(graph);
+  } catch (error) {
+    return Response.json({ message: error.message }, { status: 500 });
   }
-  const params = await request.json().catch(() => undefined);
-  const event = { payload: params };
-
-  const graph = await runGraph(env, event);
-
-  // ▼ everything below is yours — change the response, add error
-  // handling, branch on request shape, etc. Available outputs are on
-  // \`graph.*\` (one entry per step that returns a value).
-  return Response.json(graph);
-} catch (error) {
-  return Response.json({ message: error.message }, { status: 500 });
 }
+
+// Add queue handlers below using:
+// @queue function NAME(batch, env, ctx) { ... }
 `
 
 export interface GenerateScriptOptions {
@@ -267,10 +280,16 @@ export function generateScript(
   // `graph.X`. Hoisted vars (exported nodes living inside container blocks)
   // are declared via `let` at the top so the assignment can escape the block.
   const declStatement = hoistedVarNames.length > 0 ? `  let ${hoistedVarNames.join(', ')};\n` : ''
-  const returnStatement =
-    exportedVarNames.length > 0 ? `  return { ${exportedVarNames.join(', ')} };` : '  return {};'
+  const bodyAlreadyReturns = endsWithReturn(graphBody)
+  const returnStatement = bodyAlreadyReturns
+    ? ''
+    : exportedVarNames.length > 0
+      ? `  return { ${exportedVarNames.join(', ')} };`
+      : '  return {};'
+  const runGraphBody =
+    graphBody.trim().length > 0 ? indent(graphBody, 2) + (bodyAlreadyReturns ? '' : '\n') : ''
   const runGraphBlock = `async function runGraph(env: Env, event: { payload: unknown }) {
-${declStatement}${graphBody.trim().length > 0 ? indent(graphBody, 2) + '\n' : ''}${returnStatement}
+${declStatement}${runGraphBody}${returnStatement}
 }`
 
   const uniqueImports = [...new Set(collectedImports)]
@@ -279,7 +298,8 @@ ${declStatement}${graphBody.trim().length > 0 ? indent(graphBody, 2) + '\n' : ''
     !preview && classDefinitions.size > 0
       ? '\n' + [...classDefinitions.values()].join('\n\n') + '\n'
       : ''
-  const moduleCodeBlock = moduleCode.trim().length > 0 ? '\n' + moduleCode.trim() + '\n' : ''
+  const cleanedModuleCode = collapseBlankLines(moduleCode).trim()
+  const moduleCodeBlock = cleanedModuleCode.length > 0 ? '\n' + cleanedModuleCode + '\n' : ''
   const envBlock = envFields.length > 0 ? `\n${envFields.join('\n')}\n` : ''
 
   // Build the export default object — fetch handler is omitted entirely for
@@ -292,12 +312,12 @@ ${indent(fetchHandlerEmission.body, 4)}
   }
   if (queueHandlerEmissions.length > 0) {
     const cases = queueHandlerEmissions
-      .map(
-        (qh) => `      case "${qh.name}": {
-${indent(qh.body, 8)}
-        return
-      }`,
-      )
+      .map((qh) => {
+        const trailing = endsWithReturn(qh.body) ? '' : '\n        return'
+        return `      case "${qh.name}": {
+${indent(qh.body, 8)}${trailing}
+      }`
+      })
       .join('\n')
     handlerBlocks.push(`  async queue(batch: MessageBatch<unknown>, env: Env, ctx: ExecutionContext): Promise<void> {
     switch (batch.queue) {

--- a/packages/provider-cloudflare/src/codegen/generate-workflow.ts
+++ b/packages/provider-cloudflare/src/codegen/generate-workflow.ts
@@ -19,6 +19,7 @@ import {
   generateNodeCode,
   resolveNodeExpressions,
 } from './generate-helpers.js'
+import { parseAnnotations } from './parse-annotations.js'
 
 export const DEFAULT_TRIGGER_CODE = `try {
 
@@ -171,8 +172,36 @@ export function generateWorkflow(
   }
 
   const rawTriggerCode = triggerCode ?? DEFAULT_TRIGGER_CODE
-  const { imports: triggerImports, body: fetchBody } = extractImports(rawTriggerCode)
-  collectedImports.push(...triggerImports)
+  const parsed = parseAnnotations(rawTriggerCode)
+
+  // Per-block import extraction (same model as generate-script). Legacy mode
+  // is byte-identical to today; strict mode emits a fetch handler from the
+  // @fetch declaration and a switched queue handler from @queue declarations.
+  let moduleCode = ''
+  let fetchHandlerEmission: { params: string; body: string } | null = null
+  const queueHandlerEmissions: Array<{ name: string; params: string; body: string }> = []
+
+  if (parsed.mode === 'legacy') {
+    const { imports, body } = extractImports(parsed.fetchBody)
+    collectedImports.push(...imports)
+    fetchHandlerEmission = { params: 'request: Request, env: Env', body }
+  } else {
+    if (parsed.moduleCode.trim().length > 0) {
+      const { imports, body } = extractImports(parsed.moduleCode)
+      collectedImports.push(...imports)
+      moduleCode = body
+    }
+    if (parsed.fetchHandler) {
+      const { imports, body } = extractImports(parsed.fetchHandler.body)
+      collectedImports.push(...imports)
+      fetchHandlerEmission = { params: parsed.fetchHandler.params, body }
+    }
+    for (const qh of parsed.queueHandlers) {
+      const { imports, body } = extractImports(qh.body)
+      collectedImports.push(...imports)
+      queueHandlerEmissions.push({ name: qh.name, params: qh.params, body })
+    }
+  }
 
   const uniqueImports = [...new Set(collectedImports)]
   const importBlock = uniqueImports.length > 0 ? '\n' + uniqueImports.join('\n') : ''
@@ -180,23 +209,45 @@ export function generateWorkflow(
     !preview && classDefinitions.size > 0
       ? '\n' + [...classDefinitions.values()].join('\n\n') + '\n'
       : ''
+  const moduleCodeBlock = moduleCode.trim().length > 0 ? '\n' + moduleCode.trim() + '\n' : ''
+
+  const handlerBlocks: string[] = []
+  if (fetchHandlerEmission) {
+    handlerBlocks.push(`  async fetch(${fetchHandlerEmission.params}): Promise<Response> {
+${indent(fetchHandlerEmission.body, 4)}
+  },`)
+  }
+  if (queueHandlerEmissions.length > 0) {
+    const cases = queueHandlerEmissions
+      .map(
+        (qh) => `      case "${qh.name}": {
+${indent(qh.body, 8)}
+        return
+      }`,
+      )
+      .join('\n')
+    handlerBlocks.push(`  async queue(batch: MessageBatch<unknown>, env: Env, ctx: ExecutionContext): Promise<void> {
+    switch (batch.queue) {
+${cases}
+    }
+  },`)
+  }
+  const exportDefault = `export default {
+${handlerBlocks.join('\n')}
+};`
 
   return `import { WorkflowEntrypoint } from "cloudflare:workers";${importBlock}
 
 interface Env {
 ${envFields.join('\n')}
 }
-${classBlock}
+${classBlock}${moduleCodeBlock}
 export class ${className} extends WorkflowEntrypoint<Env> {
   async run(event, step) {
 ${indent(bodyLines, 4)}
   }
 }
 
-export default {
-  async fetch(request: Request, env: Env): Promise<Response> {
-${indent(fetchBody, 4)}
-  },
-};
+${exportDefault}
 `
 }

--- a/packages/provider-cloudflare/src/codegen/generate-workflow.ts
+++ b/packages/provider-cloudflare/src/codegen/generate-workflow.ts
@@ -15,36 +15,53 @@ import { hasTemplateExpressions } from './generators/state-tracking.js'
 import { detectBindings } from './bindings.js'
 import {
   CF_ENV_TYPE,
+  collapseBlankLines,
+  endsWithReturn,
   extractImports,
   generateNodeCode,
   resolveNodeExpressions,
 } from './generate-helpers.js'
 import { parseAnnotations } from './parse-annotations.js'
 
-export const DEFAULT_TRIGGER_CODE = `try {
+/**
+ * Default trigger-code scaffold for new workflows. Uses the annotated multi-handler
+ * form: `@fetch function handler(...)` for the HTTP entry point, with a comment
+ * showing how to add `@queue function NAME(...)` handlers.
+ *
+ * Top-level code outside annotated functions becomes module scope (imports,
+ * shared helpers). The @fetch handler creates and inspects workflow instances
+ * via `env.WORKFLOW`. Users can replace this code via the workflow's
+ * `triggerCode` field.
+ */
+export const DEFAULT_TRIGGER_CODE = `// import packages here
 
-const url = new URL(request.url);
+@fetch function handler(request, env, ctx) {
+  try {
+    const url = new URL(request.url);
 
-if (request.method === "POST") {
-  const params = await request.json().catch(() => undefined);
-  const instance = await env.WORKFLOW.create({ params });
-  return Response.json({ instanceId: instance.id });
-}
+    if (request.method === "POST") {
+      const params = await request.json().catch(() => undefined);
+      const instance = await env.WORKFLOW.create({ params });
+      return Response.json({ instanceId: instance.id });
+    }
 
-const instanceId = url.searchParams.get("instanceId");
-if (instanceId) {
-  const instance = await env.WORKFLOW.get(instanceId);
-  if (!instance) {
-    return Response.json({message: 'Instance not found'}, { status: 404 })
+    const instanceId = url.searchParams.get("instanceId");
+    if (instanceId) {
+      const instance = await env.WORKFLOW.get(instanceId);
+      if (!instance) {
+        return Response.json({message: 'Instance not found'}, { status: 404 })
+      }
+      return Response.json(await instance.status());
+    }
+
+    return new Response(null, { status: 200 });
+  } catch (error) {
+    return Response.json({ message: error.message }, { status: 500 });
   }
-  return Response.json(await instance.status());
 }
 
-return new Response(null, { status: 200 });
-
-} catch (error) {
-  return Response.json({ message: error.message }, { status: 500 });
-}
+// Add queue handlers below using:
+// @queue function NAME(batch, env, ctx) { ... }
 `
 
 export interface GenerateOptions {
@@ -209,7 +226,8 @@ export function generateWorkflow(
     !preview && classDefinitions.size > 0
       ? '\n' + [...classDefinitions.values()].join('\n\n') + '\n'
       : ''
-  const moduleCodeBlock = moduleCode.trim().length > 0 ? '\n' + moduleCode.trim() + '\n' : ''
+  const cleanedModuleCode = collapseBlankLines(moduleCode).trim()
+  const moduleCodeBlock = cleanedModuleCode.length > 0 ? '\n' + cleanedModuleCode + '\n' : ''
 
   const handlerBlocks: string[] = []
   if (fetchHandlerEmission) {
@@ -219,12 +237,12 @@ ${indent(fetchHandlerEmission.body, 4)}
   }
   if (queueHandlerEmissions.length > 0) {
     const cases = queueHandlerEmissions
-      .map(
-        (qh) => `      case "${qh.name}": {
-${indent(qh.body, 8)}
-        return
-      }`,
-      )
+      .map((qh) => {
+        const trailing = endsWithReturn(qh.body) ? '' : '\n        return'
+        return `      case "${qh.name}": {
+${indent(qh.body, 8)}${trailing}
+      }`
+      })
       .join('\n')
     handlerBlocks.push(`  async queue(batch: MessageBatch<unknown>, env: Env, ctx: ExecutionContext): Promise<void> {
     switch (batch.queue) {

--- a/packages/provider-cloudflare/src/codegen/generate.ts
+++ b/packages/provider-cloudflare/src/codegen/generate.ts
@@ -4,6 +4,7 @@ import { generateWorkflow } from './generate-workflow.js'
 import { generateScript } from './generate-script.js'
 
 export { extractImports, generateNodeCode } from './generate-helpers.js'
+export { deriveQueueName } from './bindings.js'
 export { DEFAULT_TRIGGER_CODE, generateWorkflow } from './generate-workflow.js'
 export type { GenerateOptions } from './generate-workflow.js'
 export { DEFAULT_SCRIPT_TRIGGER_CODE, generateScript } from './generate-script.js'

--- a/packages/provider-cloudflare/src/codegen/parse-annotations.ts
+++ b/packages/provider-cloudflare/src/codegen/parse-annotations.ts
@@ -1,0 +1,403 @@
+/**
+ * Parses trigger code for `@kind function name(params) { body }` annotations
+ * (e.g. `@fetch function handler(...)`, `@queue function emails(...)`) and
+ * extracts them as separate handler declarations. Source code outside annotated
+ * functions becomes "module-level" code in strict mode.
+ *
+ * Two parser modes, auto-detected:
+ * - **legacy**: no annotations present. Trigger code is treated as today —
+ *   the entire source is the fetch handler body.
+ * - **strict**: at least one `@fetch` or `@queue` declaration found.
+ *   Annotated functions become individual handlers; everything else at top
+ *   level becomes module scope visible to all handlers.
+ *
+ * The scanner is context-aware: annotation matches inside string literals,
+ * template literals, line comments, and block comments are ignored, so docs
+ * containing annotation-shaped text don't trigger false matches.
+ */
+export type ParsedTriggerCode = LegacyParseResult | StrictParseResult
+
+export interface LegacyParseResult {
+  mode: 'legacy'
+  fetchBody: string
+}
+
+export interface StrictParseResult {
+  mode: 'strict'
+  moduleCode: string
+  fetchHandler?: HandlerDecl
+  queueHandlers: HandlerDecl[]
+}
+
+export interface HandlerDecl {
+  name: string
+  params: string
+  body: string
+  line: number
+}
+
+export class AnnotationParseError extends Error {
+  readonly line: number
+  constructor(message: string, line: number) {
+    super(`${message} (line ${line})`)
+    this.name = 'AnnotationParseError'
+    this.line = line
+  }
+}
+
+const SUPPORTED_KINDS = new Set(['fetch', 'queue'])
+const FETCH_HANDLER_NAME = 'handler'
+const VALID_IDENTIFIER = /^[A-Za-z_$][A-Za-z0-9_$]*$/
+
+interface RawAnnotation {
+  kind: string
+  name: string
+  params: string
+  body: string
+  spanStart: number
+  spanEnd: number // exclusive
+  line: number
+}
+
+export function parseAnnotations(source: string): ParsedTriggerCode {
+  const annotations = scanAnnotations(source)
+  if (annotations.length === 0) {
+    return { mode: 'legacy', fetchBody: source }
+  }
+  return buildStrictResult(source, annotations)
+}
+
+function buildStrictResult(source: string, annotations: RawAnnotation[]): StrictParseResult {
+  let fetchHandler: HandlerDecl | undefined
+  const queueHandlers: HandlerDecl[] = []
+  const seenQueueNames = new Set<string>()
+
+  for (const ann of annotations) {
+    if (!SUPPORTED_KINDS.has(ann.kind)) {
+      throw new AnnotationParseError(
+        `Unknown annotation '@${ann.kind}'. Supported: @fetch, @queue`,
+        ann.line,
+      )
+    }
+    if (ann.kind === 'fetch') {
+      if (ann.name !== FETCH_HANDLER_NAME) {
+        throw new AnnotationParseError(
+          `@fetch annotation requires function named '${FETCH_HANDLER_NAME}', got '${ann.name}'`,
+          ann.line,
+        )
+      }
+      if (fetchHandler) {
+        throw new AnnotationParseError('Multiple @fetch handlers declared', ann.line)
+      }
+      fetchHandler = { name: ann.name, params: ann.params, body: ann.body, line: ann.line }
+    } else if (ann.kind === 'queue') {
+      if (!VALID_IDENTIFIER.test(ann.name)) {
+        throw new AnnotationParseError(
+          `@queue function name '${ann.name}' is not a valid identifier`,
+          ann.line,
+        )
+      }
+      if (seenQueueNames.has(ann.name)) {
+        throw new AnnotationParseError(`Duplicate queue handler '${ann.name}'`, ann.line)
+      }
+      seenQueueNames.add(ann.name)
+      queueHandlers.push({ name: ann.name, params: ann.params, body: ann.body, line: ann.line })
+    }
+  }
+
+  if (!fetchHandler && queueHandlers.length === 0) {
+    throw new AnnotationParseError(
+      'Workflow has no entry point. Define @fetch function handler(...) or @queue function NAME(...)',
+      1,
+    )
+  }
+
+  const moduleCode = stripSpans(
+    source,
+    annotations.map((a) => [a.spanStart, a.spanEnd] as const),
+  )
+
+  return { mode: 'strict', moduleCode, fetchHandler, queueHandlers }
+}
+
+/**
+ * Replaces each `[start, end)` span with whitespace, preserving newlines so
+ * downstream tools (sucrase error messages) keep accurate line numbers.
+ */
+function stripSpans(source: string, spans: Array<readonly [number, number]>): string {
+  if (spans.length === 0) return source
+  const sorted = [...spans].sort((a, b) => a[0] - b[0])
+  let out = ''
+  let cursor = 0
+  for (const [start, end] of sorted) {
+    out += source.slice(cursor, start)
+    for (let i = start; i < end; i++) {
+      out += source[i] === '\n' ? '\n' : ' '
+    }
+    cursor = end
+  }
+  out += source.slice(cursor)
+  return out
+}
+
+// ────────────────────────────────────────────────────────────
+// Context-aware scanner
+// ────────────────────────────────────────────────────────────
+
+type StackFrame = { type: 'template' } | { type: 'template-expr'; baseBraceDepth: number }
+
+interface ScanState {
+  inLineComment: boolean
+  inBlockComment: boolean
+  inSingleString: boolean
+  inDoubleString: boolean
+  stack: StackFrame[]
+  braceDepth: number
+  parenDepth: number
+  line: number
+}
+
+function makeState(): ScanState {
+  return {
+    inLineComment: false,
+    inBlockComment: false,
+    inSingleString: false,
+    inDoubleString: false,
+    stack: [],
+    braceDepth: 0,
+    parenDepth: 0,
+    line: 1,
+  }
+}
+
+function inAnyString(s: ScanState): boolean {
+  return s.inSingleString || s.inDoubleString
+}
+function inTemplateBody(s: ScanState): boolean {
+  return s.stack.length > 0 && s.stack[s.stack.length - 1]!.type === 'template'
+}
+function inAnyComment(s: ScanState): boolean {
+  return s.inLineComment || s.inBlockComment
+}
+function atTopLevel(s: ScanState): boolean {
+  return (
+    s.braceDepth === 0 &&
+    s.parenDepth === 0 &&
+    s.stack.length === 0 &&
+    !inAnyString(s) &&
+    !inAnyComment(s)
+  )
+}
+
+/**
+ * Advances the state machine by one character at index `i` and returns the
+ * next index to read (typically `i + 1`, but `i + 2` when consuming a
+ * two-char token like `//`, `/*`, or `${`).
+ */
+function step(source: string, i: number, state: ScanState): number {
+  const c = source[i]!
+  const next = i + 1 < source.length ? source[i + 1]! : ''
+
+  if (c === '\n') state.line++
+
+  // Escape handling inside strings & template bodies
+  if ((inAnyString(state) || inTemplateBody(state)) && c === '\\') {
+    return i + 2 // skip the escaped character
+  }
+
+  if (state.inLineComment) {
+    if (c === '\n') state.inLineComment = false
+    return i + 1
+  }
+
+  if (state.inBlockComment) {
+    if (c === '*' && next === '/') {
+      state.inBlockComment = false
+      return i + 2
+    }
+    return i + 1
+  }
+
+  if (state.inSingleString) {
+    if (c === "'") state.inSingleString = false
+    return i + 1
+  }
+
+  if (state.inDoubleString) {
+    if (c === '"') state.inDoubleString = false
+    return i + 1
+  }
+
+  if (inTemplateBody(state)) {
+    if (c === '`') {
+      state.stack.pop()
+      return i + 1
+    }
+    if (c === '$' && next === '{') {
+      state.stack.push({ type: 'template-expr', baseBraceDepth: state.braceDepth })
+      state.braceDepth++
+      return i + 2
+    }
+    return i + 1
+  }
+
+  // Inside JS code (top-level OR inside a template-expr `${...}`)
+  if (c === '/' && next === '/') {
+    state.inLineComment = true
+    return i + 2
+  }
+  if (c === '/' && next === '*') {
+    state.inBlockComment = true
+    return i + 2
+  }
+  if (c === "'") {
+    state.inSingleString = true
+    return i + 1
+  }
+  if (c === '"') {
+    state.inDoubleString = true
+    return i + 1
+  }
+  if (c === '`') {
+    state.stack.push({ type: 'template' })
+    return i + 1
+  }
+  if (c === '{') {
+    state.braceDepth++
+    return i + 1
+  }
+  if (c === '}') {
+    state.braceDepth--
+    // If this `}` closes a template-expr (we're back to its base depth), pop
+    // the template-expr frame so we re-enter template-body mode.
+    const top = state.stack[state.stack.length - 1]
+    if (top && top.type === 'template-expr' && top.baseBraceDepth === state.braceDepth) {
+      state.stack.pop()
+    }
+    return i + 1
+  }
+  if (c === '(') {
+    state.parenDepth++
+    return i + 1
+  }
+  if (c === ')') {
+    state.parenDepth--
+    return i + 1
+  }
+
+  return i + 1
+}
+
+/**
+ * Scans the source for annotations of the form
+ *   @<kind> function <name>(<params>) { <body> }
+ * Walks the entire source character-by-character with full context tracking
+ * (strings/templates/comments/braces). Records every `@<kind>` match seen
+ * outside string/comment context — top-level matches become real annotations,
+ * non-top-level matches throw if they reference a supported annotation kind.
+ */
+function scanAnnotations(source: string): RawAnnotation[] {
+  interface PendingAnnotation {
+    spanStart: number
+    line: number
+    header: AnnotationHeader
+  }
+  const pending: PendingAnnotation[] = []
+  const state = makeState()
+  let i = 0
+
+  while (i < source.length) {
+    if (
+      source[i] === '@' &&
+      !inAnyString(state) &&
+      !inAnyComment(state) &&
+      !inTemplateBody(state)
+    ) {
+      const match = matchAnnotationHeader(source, i)
+      if (match) {
+        if (atTopLevel(state)) {
+          pending.push({ spanStart: i, line: state.line, header: match })
+        } else if (SUPPORTED_KINDS.has(match.kind)) {
+          throw new AnnotationParseError(
+            `Annotation '@${match.kind}' must be declared at top level, not inside another function or block`,
+            state.line,
+          )
+        }
+      }
+    }
+    i = step(source, i, state)
+  }
+
+  return pending.map(({ spanStart, line, header }) => {
+    const bodyEnd = findBodyEnd(source, header.bodyStart, line)
+    const body = source.slice(header.bodyStart + 1, bodyEnd)
+    return {
+      kind: header.kind,
+      name: header.name,
+      params: header.params,
+      body,
+      spanStart,
+      spanEnd: bodyEnd + 1,
+      line,
+    }
+  })
+}
+
+interface AnnotationHeader {
+  kind: string
+  name: string
+  params: string
+  bodyStart: number // index of opening `{`
+}
+
+const HEADER_REGEX = /^@(\w+)[ \t]+function[ \t]+(\w+)[ \t]*\(([^)]*)\)[ \t\r\n]*\{/
+
+/**
+ * Tries to match an annotation header starting at `i`. Returns the parsed
+ * fields and the index of the opening `{`, or null if no match.
+ */
+function matchAnnotationHeader(source: string, i: number): AnnotationHeader | null {
+  const remaining = source.slice(i)
+  const m = HEADER_REGEX.exec(remaining)
+  if (!m) return null
+  const fullMatch = m[0]
+  const kind = m[1]!
+  const name = m[2]!
+  const params = m[3]!
+  return {
+    kind,
+    name,
+    params,
+    bodyStart: i + fullMatch.length - 1, // index of the `{`
+  }
+}
+
+/**
+ * Walks from the opening `{` at `bodyStart` until the matching `}`, respecting
+ * nested strings / templates / comments / braces. Returns the index of the
+ * matching `}`. Throws if EOF is reached without finding it.
+ */
+function findBodyEnd(source: string, bodyStart: number, openLine: number): number {
+  const inner = makeState()
+  // Consume the opening `{` — braceDepth becomes 1.
+  let i = step(source, bodyStart, inner)
+  while (i < source.length) {
+    i = step(source, i, inner)
+    // Step has advanced past one or more chars. If brace depth just returned
+    // to zero (and we're not inside a string/comment/template/paren), we just
+    // processed the matching `}` and `i` is one position past it.
+    if (
+      inner.braceDepth === 0 &&
+      inner.parenDepth === 0 &&
+      inner.stack.length === 0 &&
+      !inAnyString(inner) &&
+      !inAnyComment(inner)
+    ) {
+      return i - 1
+    }
+  }
+  throw new AnnotationParseError(
+    'Unclosed annotated function body — missing matching "}"',
+    openLine,
+  )
+}

--- a/packages/provider-cloudflare/src/codegen/parse-annotations.ts
+++ b/packages/provider-cloudflare/src/codegen/parse-annotations.ts
@@ -1,3 +1,5 @@
+import { cloudflareInlineQueueConfigSchema } from '../config-schema.js'
+
 /**
  * Parses trigger code for `@kind function name(params) { body }` annotations
  * (e.g. `@fetch function handler(...)`, `@queue function emails(...)`) and
@@ -34,6 +36,13 @@ export interface HandlerDecl {
   params: string
   body: string
   line: number
+  /**
+   * For `@queue` handlers, optional inline configuration parsed from a
+   * leading `@config { … }` block. Keys are camelCase (snake_case in the
+   * source is normalized at parse time). Validated against
+   * `cloudflareInlineQueueConfigSchema`.
+   */
+  config?: Record<string, string | number | boolean>
 }
 
 export class AnnotationParseError extends Error {
@@ -101,7 +110,14 @@ function buildStrictResult(source: string, annotations: RawAnnotation[]): Strict
         throw new AnnotationParseError(`Duplicate queue handler '${ann.name}'`, ann.line)
       }
       seenQueueNames.add(ann.name)
-      queueHandlers.push({ name: ann.name, params: ann.params, body: ann.body, line: ann.line })
+      const { config, cleanedBody } = extractConfigBlock(ann.body, ann.line)
+      queueHandlers.push({
+        name: ann.name,
+        params: ann.params,
+        body: cleanedBody,
+        line: ann.line,
+        ...(config && { config }),
+      })
     }
   }
 
@@ -400,4 +416,207 @@ function findBodyEnd(source: string, bodyStart: number, openLine: number): numbe
     'Unclosed annotated function body — missing matching "}"',
     openLine,
   )
+}
+
+// ────────────────────────────────────────────────────────────
+// @config block parsing (inline queue consumer settings)
+// ────────────────────────────────────────────────────────────
+
+const SNAKE_TO_CAMEL_KEY_MAP: Record<string, string> = {
+  max_batch_size: 'maxBatchSize',
+  max_batch_timeout: 'maxBatchTimeout',
+  max_retries: 'maxRetries',
+  dead_letter_queue: 'deadLetterQueue',
+  max_concurrency: 'maxConcurrency',
+}
+
+const KNOWN_CONFIG_KEYS = new Set([
+  ...Object.keys(SNAKE_TO_CAMEL_KEY_MAP),
+  ...Object.values(SNAKE_TO_CAMEL_KEY_MAP),
+])
+
+const NUMERIC_CONFIG_KEYS = new Set([
+  'maxBatchSize',
+  'maxBatchTimeout',
+  'maxRetries',
+  'maxConcurrency',
+])
+
+/**
+ * Looks for a leading `@config { ... }` block in a queue handler body. If
+ * present, parses it, validates against the inline queue config schema, and
+ * returns both the parsed config and the body with the block stripped.
+ *
+ * Only the FIRST statement-position `@config` is recognized. Multiple blocks
+ * or non-leading placement → throws.
+ */
+function extractConfigBlock(
+  body: string,
+  handlerLine: number,
+): {
+  config?: Record<string, string | number | boolean>
+  cleanedBody: string
+} {
+  const headerMatch = /^([\s]*)@config\s*\{/.exec(body)
+  if (!headerMatch) {
+    // No leading config — but reject any later occurrence to avoid silent
+    // miscounts (it's almost always a user error to put @config mid-body).
+    if (/(^|\n)\s*@config\s*\{/.test(body)) {
+      throw new AnnotationParseError(
+        '@config block must be at the start of the queue handler body',
+        handlerLine,
+      )
+    }
+    return { cleanedBody: body }
+  }
+  const openBraceIdx = headerMatch.index + headerMatch[0].length - 1
+  const closeBraceIdx = findConfigCloseBrace(body, openBraceIdx, handlerLine)
+  const inner = body.slice(openBraceIdx + 1, closeBraceIdx)
+
+  // Reject duplicate @config blocks (anything after the first one).
+  const remainder = body.slice(closeBraceIdx + 1)
+  if (/(^|\n)\s*@config\s*\{/.test(remainder)) {
+    throw new AnnotationParseError('Duplicate @config block in queue handler body', handlerLine)
+  }
+
+  const parsed = parseConfigContent(inner, handlerLine)
+  const validation = cloudflareInlineQueueConfigSchema.safeParse(parsed)
+  if (!validation.success) {
+    const issue = validation.error.issues[0]
+    const path = issue?.path.join('.') ?? '?'
+    throw new AnnotationParseError(
+      `@config validation failed at '${path}': ${issue?.message ?? 'invalid value'}`,
+      handlerLine,
+    )
+  }
+
+  const cleanedBody = body.slice(0, headerMatch.index) + remainder
+  return { config: validation.data, cleanedBody }
+}
+
+/**
+ * Walks from the opening `{` of a `@config` block to its matching `}`,
+ * tracking string/template/comment context so braces inside string literals
+ * don't confuse the matcher.
+ */
+function findConfigCloseBrace(body: string, openIdx: number, line: number): number {
+  const inner = makeState()
+  let i = step(body, openIdx, inner)
+  while (i < body.length) {
+    i = step(body, i, inner)
+    if (
+      inner.braceDepth === 0 &&
+      inner.parenDepth === 0 &&
+      inner.stack.length === 0 &&
+      !inAnyString(inner) &&
+      !inAnyComment(inner)
+    ) {
+      return i - 1
+    }
+  }
+  throw new AnnotationParseError('Unclosed @config block — missing matching "}"', line)
+}
+
+/**
+ * Parses the inside of a `@config { … }` block into a key/value object.
+ * Supports a small JSON-like subset:
+ *   - unquoted snake_case or camelCase keys
+ *   - string values: "foo" or 'foo'
+ *   - number values: 10, 0, 5.5
+ *   - boolean values: true, false
+ *   - trailing commas allowed
+ *   - line/block comments allowed
+ *
+ * snake_case keys are normalized to camelCase. Unknown keys throw.
+ */
+function parseConfigContent(
+  content: string,
+  line: number,
+): Record<string, string | number | boolean> {
+  const cleaned = content.replace(/\/\/[^\n]*/g, '').replace(/\/\*[\s\S]*?\*\//g, '')
+  const out: Record<string, string | number | boolean> = {}
+  const pairs = splitTopLevelCommas(cleaned)
+  for (const raw of pairs) {
+    const pair = raw.trim()
+    if (!pair) continue
+    const colonIdx = pair.indexOf(':')
+    if (colonIdx === -1) {
+      throw new AnnotationParseError(`@config: expected 'key: value', got '${pair}'`, line)
+    }
+    const rawKey = pair.slice(0, colonIdx).trim()
+    const rawValue = pair.slice(colonIdx + 1).trim()
+    if (!/^[a-zA-Z_][a-zA-Z0-9_]*$/.test(rawKey)) {
+      throw new AnnotationParseError(`@config: invalid key '${rawKey}'`, line)
+    }
+    if (!KNOWN_CONFIG_KEYS.has(rawKey)) {
+      throw new AnnotationParseError(
+        `@config: unknown key '${rawKey}'. Allowed: ${[...Object.keys(SNAKE_TO_CAMEL_KEY_MAP)].join(', ')}`,
+        line,
+      )
+    }
+    const key = SNAKE_TO_CAMEL_KEY_MAP[rawKey] ?? rawKey
+    out[key] = parseConfigValue(rawValue, key, line)
+  }
+  return out
+}
+
+function parseConfigValue(s: string, key: string, line: number): string | number | boolean {
+  if (s === 'true') return true
+  if (s === 'false') return false
+  if ((s.startsWith('"') && s.endsWith('"')) || (s.startsWith("'") && s.endsWith("'"))) {
+    const stringValue = s.slice(1, -1)
+    // Lenient coercion: numeric keys accept "10" or "5s" (CF's wrangler
+    // accepts seconds as integer; strip the trailing 's' and parse).
+    if (NUMERIC_CONFIG_KEYS.has(key)) {
+      const trimmed = stringValue.replace(/s$/i, '')
+      const n = Number(trimmed)
+      if (!Number.isNaN(n)) return n
+      throw new AnnotationParseError(
+        `@config: '${key}' expected a number, got '${stringValue}'`,
+        line,
+      )
+    }
+    return stringValue
+  }
+  const n = Number(s)
+  if (!Number.isNaN(n) && s !== '') return n
+  throw new AnnotationParseError(`@config: cannot parse value '${s}' for '${key}'`, line)
+}
+
+/** Splits a string by commas at the top level (depth 0 of `{}`, `[]`, `()`). */
+function splitTopLevelCommas(s: string): string[] {
+  const out: string[] = []
+  let depth = 0
+  let inSingle = false
+  let inDouble = false
+  let start = 0
+  for (let i = 0; i < s.length; i++) {
+    const c = s[i]!
+    if (inSingle) {
+      if (c === '\\' && i + 1 < s.length) {
+        i++
+        continue
+      }
+      if (c === "'") inSingle = false
+      continue
+    }
+    if (inDouble) {
+      if (c === '\\' && i + 1 < s.length) {
+        i++
+        continue
+      }
+      if (c === '"') inDouble = false
+      continue
+    }
+    if (c === "'") inSingle = true
+    else if (c === '"') inDouble = true
+    else if (c === '{' || c === '[' || c === '(') depth++
+    else if (c === '}' || c === ']' || c === ')') depth--
+    else if (c === ',' && depth === 0) {
+      out.push(s.slice(start, i))
+      start = i + 1
+    }
+  }
+  if (start < s.length) out.push(s.slice(start))
+  return out
 }

--- a/packages/provider-cloudflare/src/config-schema.ts
+++ b/packages/provider-cloudflare/src/config-schema.ts
@@ -6,6 +6,31 @@ export const cloudflareRouteSchema = z.object({
   zoneName: z.string().min(1),
 })
 
+/**
+ * Schema for one queue-consumer entry. Reused by both:
+ * - `cloudflareDeploymentConfigSchema.queueConsumers` (per-deploy overrides)
+ * - the inline `@config { ... }` block parser inside a `@queue function`
+ *   handler body (which omits `queue` since it's derived from the function name)
+ */
+export const cloudflareQueueConsumerSchema = z
+  .object({
+    queue: z.string().min(1),
+    maxBatchSize: z.number().int().min(1).max(100).optional(),
+    maxBatchTimeout: z.number().int().min(0).max(60).optional(),
+    maxRetries: z.number().int().min(0).max(100).optional(),
+    deadLetterQueue: z.string().min(1).optional(),
+    maxConcurrency: z.number().int().min(1).max(20).optional(),
+  })
+  .strict()
+
+/** Same as above but without the `queue` field — used for inline `@config` blocks. */
+export const cloudflareInlineQueueConfigSchema = cloudflareQueueConsumerSchema
+  .omit({ queue: true })
+  .strict()
+
+export type CloudflareQueueConsumer = z.infer<typeof cloudflareQueueConsumerSchema>
+export type CloudflareInlineQueueConfig = z.infer<typeof cloudflareInlineQueueConfigSchema>
+
 export const cloudflareDeploymentConfigSchema = z
   .object({
     // Routing
@@ -54,20 +79,7 @@ export const cloudflareDeploymentConfigSchema = z
     // Per-queue consumer settings — populated automatically from `@queue function NAME(...)`
     // declarations in trigger code. Each entry tunes the consumer for one queue
     // name. Cloudflare defaults apply to fields left undefined.
-    queueConsumers: z
-      .array(
-        z
-          .object({
-            queue: z.string().min(1),
-            maxBatchSize: z.number().int().min(1).max(100).optional(),
-            maxBatchTimeout: z.number().int().min(0).max(60).optional(),
-            maxRetries: z.number().int().min(0).max(100).optional(),
-            deadLetterQueue: z.string().min(1).optional(),
-            maxConcurrency: z.number().int().min(1).max(20).optional(),
-          })
-          .strict(),
-      )
-      .optional(),
+    queueConsumers: z.array(cloudflareQueueConsumerSchema).optional(),
   })
   .strict()
 

--- a/packages/provider-cloudflare/src/config-schema.ts
+++ b/packages/provider-cloudflare/src/config-schema.ts
@@ -50,6 +50,24 @@ export const cloudflareDeploymentConfigSchema = z
       )
       .optional(),
     logpush: z.boolean().optional(),
+
+    // Per-queue consumer settings — populated automatically from `@queue function NAME(...)`
+    // declarations in trigger code. Each entry tunes the consumer for one queue
+    // name. Cloudflare defaults apply to fields left undefined.
+    queueConsumers: z
+      .array(
+        z
+          .object({
+            queue: z.string().min(1),
+            maxBatchSize: z.number().int().min(1).max(100).optional(),
+            maxBatchTimeout: z.number().int().min(0).max(60).optional(),
+            maxRetries: z.number().int().min(0).max(100).optional(),
+            deadLetterQueue: z.string().min(1).optional(),
+            maxConcurrency: z.number().int().min(1).max(20).optional(),
+          })
+          .strict(),
+      )
+      .optional(),
   })
   .strict()
 

--- a/packages/provider-cloudflare/src/deploy/deployer.ts
+++ b/packages/provider-cloudflare/src/deploy/deployer.ts
@@ -81,6 +81,15 @@ export interface DeployOptions {
   limits?: { cpuMs?: number }
   observability?: { enabled: boolean; headSamplingRate?: number }
   logpush?: boolean
+  /** Per-queue consumer settings; emitted as `queues.consumers[]` in wrangler.json. */
+  queueConsumers?: Array<{
+    queue: string
+    maxBatchSize?: number
+    maxBatchTimeout?: number
+    maxRetries?: number
+    deadLetterQueue?: string
+    maxConcurrency?: number
+  }>
 }
 
 export interface WranglerDeployResult {

--- a/packages/provider-cloudflare/src/deploy/node-deployer.ts
+++ b/packages/provider-cloudflare/src/deploy/node-deployer.ts
@@ -55,6 +55,7 @@ export class NodeWranglerDeployer implements WranglerDeployer {
         limits: options.limits,
         observability: options.observability,
         logpush: options.logpush,
+        queueConsumers: options.queueConsumers,
       })
       await writeFile(join(deployDir, 'wrangler.json'), wranglerConfig, 'utf-8')
 

--- a/packages/provider-cloudflare/src/deploy/sandbox-deployer.ts
+++ b/packages/provider-cloudflare/src/deploy/sandbox-deployer.ts
@@ -76,6 +76,7 @@ export class SandboxWranglerDeployer implements WranglerDeployer {
         limits: options.limits,
         observability: options.observability,
         logpush: options.logpush,
+        queueConsumers: options.queueConsumers,
       })
       await sandbox.writeFile('/workspace/wrangler.json', wranglerConfig)
 

--- a/packages/provider-cloudflare/src/index.ts
+++ b/packages/provider-cloudflare/src/index.ts
@@ -10,6 +10,7 @@ export type { GenerateOptions, GenerateScriptOptions } from './codegen/generate.
 export {
   detectBindings,
   detectBindingsFromSource,
+  deriveQueueName,
   type BindingRequirement,
   type BindingType,
 } from './codegen/bindings.js'

--- a/packages/provider-cloudflare/src/wrangler-config.ts
+++ b/packages/provider-cloudflare/src/wrangler-config.ts
@@ -1,4 +1,4 @@
-import type { BindingRequirement } from './codegen/bindings.js'
+import { deriveQueueName, type BindingRequirement } from './codegen/bindings.js'
 import type { SubWorkflowBinding } from './codegen/generators/sub-workflow.js'
 
 export const WRANGLER_BASE_CONFIG = {
@@ -166,7 +166,10 @@ export function generateWranglerConfig(config: WranglerWorkflowConfig): string {
           r2Bindings.push({ binding: b.name, bucket_name: b.resourceId ?? b.name.toLowerCase() })
           break
         case 'queue':
-          queueProducers.push({ binding: b.name, queue: b.resourceId ?? b.name.toLowerCase() })
+          // Default queue name strips the `QUEUE_` prefix so producer and
+          // consumer (`@queue function NAME`) agree on the same CF queue.
+          // Users can override via the `<NAME>_BINDING_ID` env var convention.
+          queueProducers.push({ binding: b.name, queue: b.resourceId ?? deriveQueueName(b.name) })
           break
         case 'service':
           serviceBindings.push({ binding: b.name, service: b.resourceId ?? b.name.toLowerCase() })

--- a/packages/provider-cloudflare/src/wrangler-config.ts
+++ b/packages/provider-cloudflare/src/wrangler-config.ts
@@ -35,6 +35,20 @@ export interface WranglerWorkflowConfig {
   limits?: { cpuMs?: number }
   observability?: { enabled: boolean; headSamplingRate?: number }
   logpush?: boolean
+  /**
+   * Per-queue consumer settings — populated by the adapter from `@queue function NAME`
+   * annotations cross-referenced with the deployment config's `queueConsumers`.
+   * Each entry produces one `queues.consumers[]` row in the emitted wrangler config.
+   * Cloudflare defaults apply to fields left undefined.
+   */
+  queueConsumers?: Array<{
+    queue: string
+    maxBatchSize?: number
+    maxBatchTimeout?: number
+    maxRetries?: number
+    deadLetterQueue?: string
+    maxConcurrency?: number
+  }>
   localDev?: boolean
 }
 
@@ -191,7 +205,10 @@ export function generateWranglerConfig(config: WranglerWorkflowConfig): string {
     if (kvBindings.length > 0) wranglerConfig.kv_namespaces = kvBindings
     if (d1Bindings.length > 0) wranglerConfig.d1_databases = d1Bindings
     if (r2Bindings.length > 0) wranglerConfig.r2_buckets = r2Bindings
-    if (queueProducers.length > 0) wranglerConfig.queues = { producers: queueProducers }
+    if (queueProducers.length > 0) {
+      const existing = (wranglerConfig.queues ?? {}) as Record<string, unknown>
+      wranglerConfig.queues = { ...existing, producers: queueProducers }
+    }
     if (serviceBindings.length > 0) wranglerConfig.services = serviceBindings
     if (aiBinding) wranglerConfig.ai = aiBinding
     if (vectorizeBindings.length > 0) wranglerConfig.vectorize = vectorizeBindings
@@ -199,6 +216,20 @@ export function generateWranglerConfig(config: WranglerWorkflowConfig): string {
       wranglerConfig.analytics_engine_datasets = analyticsEngineBindings
     if (hyperdriveBindings.length > 0) wranglerConfig.hyperdrive = hyperdriveBindings
     if (browserBinding) wranglerConfig.browser = browserBinding
+  }
+
+  if (config.queueConsumers && config.queueConsumers.length > 0) {
+    const consumers = config.queueConsumers.map((c) => {
+      const out: Record<string, unknown> = { queue: c.queue }
+      if (c.maxBatchSize !== undefined) out.max_batch_size = c.maxBatchSize
+      if (c.maxBatchTimeout !== undefined) out.max_batch_timeout = c.maxBatchTimeout
+      if (c.maxRetries !== undefined) out.max_retries = c.maxRetries
+      if (c.deadLetterQueue !== undefined) out.dead_letter_queue = c.deadLetterQueue
+      if (c.maxConcurrency !== undefined) out.max_concurrency = c.maxConcurrency
+      return out
+    })
+    const existing = (wranglerConfig.queues ?? {}) as Record<string, unknown>
+    wranglerConfig.queues = { ...existing, consumers }
   }
 
   return JSON.stringify(wranglerConfig, null, 2)


### PR DESCRIPTION
## Summary

Lets a single Cloudflare Worker source declare multiple handlers via top-level annotations:

- `@fetch function handler(request, env, ctx) { ... }` — HTTP entry point
- `@queue function NAME(batch, env, ctx) { ... }` — queue consumer (one per queue)
- `@config { max_batch_size: N, max_retries: N, dead_letter_queue: "...", ... }` — per-queue tuning, declared inline at the start of a `@queue` body

The parser strips annotated function declarations before sucrase sees them (sidesteps TS decorator syntax), runs context-aware brace matching with full string/template/comment awareness, validates per-queue config via the existing zod schema, and produces a structured tree the generators consume.

Codegen emits one handler per annotation in `export default`, dispatches queue messages on `batch.queue`, and wires `queues.consumers[]` in `wrangler.json` from parsed `@queue function NAME` annotations. Per-queue settings merge in priority order: `deploymentConfig.queueConsumers` (per-environment override) > inline `@config` block (source default) > CF defaults.

## Backwards compatibility

A trigger code with no annotations stays in **legacy mode** — byte-identical output to today, single typed `async fetch(request: Request, env: Env)` handler. Existing workflows continue to deploy without modification.

The new default scaffolding (`DEFAULT_SCRIPT_TRIGGER_CODE` / `DEFAULT_TRIGGER_CODE`) ships with the strict-mode `@fetch function handler(...)` form. New workflows start in strict mode.

One real breaking-shape change: the default queue producer name now strips the `QUEUE_` prefix (`QUEUE_EMAILS` → `emails`) so it aligns with the consumer side. Users who relied on the old `queue_emails` derivation can preserve it via the existing `<NAME>_BINDING_ID` env var override.

## Implementation order (8 mergeable commits)

1. **Parser + 26 tests.** Pure module, no other changes.
2. **Schema field** for `queueConsumers` in `cloudflareDeploymentConfigSchema`.
3. **`generate-script.ts` integration** — emits @fetch + switched @queue handlers; module code goes between class definitions and runGraph.
4. **`generate-workflow.ts` integration** — same pattern for workflow IRs.
5. **Wrangler `queues.consumers` emission** + `buildQueueConsumers` helper.
6. **Default scaffolding** uses @fetch form; `collapseBlankLines` + `endsWithReturn` cleanup helpers added.
7. **Bindings panel "+ Consume" button** + producer/consumer queue name alignment fix.
8. **Inline `@config` block** for per-queue settings; replaces a planned deploy form auto-populate UI.

## Tests

- 1315 tests pass (was 1280 on main, +35 new across parser, codegen, wrangler config, adapter, schema)
- `pnpm lint`, `pnpm type-check`, `pnpm build` all clean

## Test plan

- [x] All packages: build / lint / type-check / test
- [x] Parser context-aware: annotations inside string literals, template literals, JSDoc, line comments, block comments are correctly ignored
- [x] Producer + consumer queue name alignment for default `QUEUE_X` → queue `x`
- [x] `@config` validation rejects out-of-range values at parse time (catches `max_batch_size: 200` etc.)
- [x] Three-layer merge for queue consumer settings: deployment override > inline `@config` > CF defaults
- [ ] Manual: deploy a script with `@fetch` + `@queue function email` + send a message to the `email` queue, confirm handler fires
- [ ] Manual: deploy a script with `@queue function jobs` + `@config { max_batch_size: 1 }`, verify wrangler.json has the right consumer settings
- [ ] Manual: legacy trigger code (existing workflow with raw try/catch) still deploys identically
- [ ] Manual: bindings panel "+ Consume" button inserts a `@queue` handler and opens the editor

## Out of scope (deferred)

- `@scheduled`, `@email`, `@tail`, `@rpc` annotations (parser is general; emitting these is mostly wrangler config + handler shape work)
- Editor syntax highlighting / outline view for annotation lines
- Deploy form UI for queue consumers (replaced by inline `@config`)