### PR TITLE
fix(canvas): allow single-branch and post-branch continuation

### DIFF
--- a/apps/web/src/components/canvas/node-config-panel.tsx
+++ b/apps/web/src/components/canvas/node-config-panel.tsx
@@ -432,7 +432,27 @@ function BranchFields({
         <span>Add condition</span>
       </Button>
 
-      <Hint>Select which node each branch should go to. Edges are created automatically.</Hint>
+      <div className="overflow-hidden rounded-lg border border-border">
+        <div className="bg-muted/40 px-3 py-1.5">
+          <span className="text-xs font-medium text-muted-foreground">After branch</span>
+        </div>
+        <div className="p-3">
+          <div className="space-y-1">
+            <Label className="text-xs text-muted-foreground/60">Continue to</Label>
+            <Select
+              value={getTargetForLabel('then') || '__none__'}
+              onValueChange={(v) => setTargetForBranch('then', v === '__none__' ? '' : v)}
+              options={[{ value: '__none__', label: 'Not connected' }, ...targetOptions]}
+              className="h-8 text-xs"
+            />
+          </div>
+        </div>
+      </div>
+
+      <Hint>
+        Pick a target for each branch. A single condition is fine (no else needed). Use{' '}
+        <strong>Continue to</strong> for a node that runs after the entire if/else.
+      </Hint>
     </>
   )
 }

--- a/apps/web/src/lib/__tests__/validate-workflow.test.ts
+++ b/apps/web/src/lib/__tests__/validate-workflow.test.ts
@@ -252,7 +252,7 @@ describe('validateWorkflowForPublish', () => {
   // ── branch ──
 
   describe('branch', () => {
-    it('errors with fewer than 2 branches', () => {
+    it('accepts a single-condition branch (if without else)', () => {
       const node = makeFlowNode({
         id: 'b1',
         type: 'branch',
@@ -262,9 +262,38 @@ describe('validateWorkflowForPublish', () => {
         provider: 'cloudflare',
         data: { branches: [{ label: 'yes', condition: 'true' }] },
       })
+      const target = makeFlowNode({
+        id: 'inside',
+        type: 'step',
+        name: 'Inside',
+        position: { x: 0, y: 0 },
+        version: '1.0.0',
+        provider: 'cloudflare',
+        data: { code: 'return 1;' },
+      })
+      const result = validateWorkflowForPublish(
+        makeMetadata(),
+        [node, target],
+        [{ id: 'e0', source: 'b1', target: 'inside', label: 'yes' }],
+      )
+      expect(result.issues).not.toContainEqual(
+        expect.objectContaining({ severity: 'error', message: expect.stringMatching(/branches/i) }),
+      )
+    })
+
+    it('errors with zero branches', () => {
+      const node = makeFlowNode({
+        id: 'b1',
+        type: 'branch',
+        name: 'Check',
+        position: { x: 0, y: 0 },
+        version: '1.0.0',
+        provider: 'cloudflare',
+        data: { branches: [] },
+      })
       const result = validateWorkflowForPublish(makeMetadata(), [node], [])
       expect(result.issues).toContainEqual(
-        expect.objectContaining({ severity: 'error', message: 'Fewer than 2 branches' }),
+        expect.objectContaining({ severity: 'error', message: 'Branch has no conditions' }),
       )
     })
 

--- a/apps/web/src/lib/validate-workflow.ts
+++ b/apps/web/src/lib/validate-workflow.ts
@@ -330,8 +330,10 @@ export function validateWorkflowForPublish(
 
       case 'branch': {
         const branches = (ir.data.branches ?? []) as BranchCondition[]
-        if (branches.length < 2) {
-          add('error', id, name, 'Fewer than 2 branches')
+        // A branch with no branches at all isn't useful — it'd emit nothing.
+        // A single-branch case (`if (cond) { ... }` with no else) IS valid.
+        if (branches.length < 1) {
+          add('error', id, name, 'Branch has no conditions')
         }
 
         const labels = branches.map((b) => b.label)

--- a/apps/web/src/stores/workflow-store.ts
+++ b/apps/web/src/stores/workflow-store.ts
@@ -292,6 +292,14 @@ export const useWorkflowStore = create<WorkflowState>((set, get) => ({
       else if (!labels.has('finally')) label = 'finally'
       else if (!labels.has('then')) label = 'then'
       else return
+    } else if (type === 'branch') {
+      // Per-branch wiring (yes/no/etc.) is done via the config panel, which
+      // sets explicit branch labels. A direct drag from the branch's source
+      // handle is for the continuation path that runs after the if/else
+      // block returns — auto-label as 'then'. Block if one already exists.
+      const labels = new Set(outgoing!.map((e) => e.label))
+      if (!labels.has('then')) label = 'then'
+      else return
     }
 
     const newEdge = { ...connection, id: nanoid(), ...(label ? { label } : {}) }

--- a/packages/provider-cloudflare/src/__tests__/codegen/generate.test.ts
+++ b/packages/provider-cloudflare/src/__tests__/codegen/generate.test.ts
@@ -81,6 +81,93 @@ describe('generateWorkflow', () => {
     expect(code).toContain('fetch("https://api.example.com/notify"')
   })
 
+  it('generates a single-branch (if without else)', () => {
+    const ir: WorkflowIR = {
+      metadata: { name: 'single-branch-test', version: 1, createdAt: '', updatedAt: '' },
+      nodes: [
+        {
+          id: 'br',
+          type: 'branch',
+          name: 'Maybe run',
+          position: { x: 0, y: 0 },
+          version: '1.0.0',
+          provider: 'cloudflare',
+          data: { branches: [{ label: 'yes', condition: 'true' }] },
+        },
+        {
+          id: 's1',
+          type: 'step',
+          name: 'Inside',
+          position: { x: 0, y: 0 },
+          version: '1.0.0',
+          provider: 'cloudflare',
+          data: { code: 'return 1;' },
+        },
+      ],
+      edges: [{ id: 'e0', source: 'br', target: 's1', label: 'yes' }],
+      entryNodeId: 'br',
+    }
+    const code = generateWorkflow(ir)
+    expect(code).toContain('if (true) {')
+    expect(code).not.toContain('} else {')
+    expect(code).toContain('step.do("Inside"')
+  })
+
+  it('emits a "then" continuation node AFTER the branch block', () => {
+    const ir: WorkflowIR = {
+      metadata: { name: 'branch-then-test', version: 1, createdAt: '', updatedAt: '' },
+      nodes: [
+        {
+          id: 'br',
+          type: 'branch',
+          name: 'Check',
+          position: { x: 0, y: 0 },
+          version: '1.0.0',
+          provider: 'cloudflare',
+          data: { branches: [{ label: 'yes', condition: 'true' }] },
+        },
+        {
+          id: 's1',
+          type: 'step',
+          name: 'Inside',
+          position: { x: 0, y: 0 },
+          version: '1.0.0',
+          provider: 'cloudflare',
+          data: { code: 'return 1;' },
+        },
+        {
+          id: 's2',
+          type: 'step',
+          name: 'After branch',
+          position: { x: 0, y: 0 },
+          version: '1.0.0',
+          provider: 'cloudflare',
+          data: { code: 'return 2;' },
+        },
+      ],
+      edges: [
+        { id: 'e0', source: 'br', target: 's1', label: 'yes' },
+        { id: 'e1', source: 'br', target: 's2', label: 'then' },
+      ],
+      entryNodeId: 'br',
+    }
+    const code = generateWorkflow(ir)
+    // Branch body present
+    expect(code).toContain('if (true) {')
+    expect(code).toContain('step.do("Inside"')
+    // Continuation step also present, AFTER the branch's closing brace
+    expect(code).toContain('step.do("After branch"')
+    const branchCloseIdx = code.lastIndexOf('}')
+    const afterBranchIdx = code.indexOf('step.do("After branch"')
+    // The continuation must appear in the source after the branch close — i.e.,
+    // not inlined inside the if/else.
+    expect(afterBranchIdx).toBeGreaterThan(0)
+    // Sanity: the inside step appears BEFORE the continuation step
+    const insideIdx = code.indexOf('step.do("Inside"')
+    expect(insideIdx).toBeLessThan(afterBranchIdx)
+    expect(branchCloseIdx).toBeGreaterThan(0) // matched some closing brace
+  })
+
   it('generates a parallel workflow', () => {
     const code = generateWorkflow(parallelWorkflow as unknown as WorkflowIR)
     expect(code).toContain('Promise.allSettled')

--- a/packages/provider-cloudflare/src/__tests__/codegen/generators/branch.test.ts
+++ b/packages/provider-cloudflare/src/__tests__/codegen/generators/branch.test.ts
@@ -318,6 +318,52 @@ describe('collectBranchInlineTargets', () => {
     expect(inlineTargets.has('branch-1')).toBe(false)
   })
 
+  it('does not collect a "then" continuation target as inline', () => {
+    // The continuation node connected via the `then` edge should NOT be
+    // inlined inside the if/else — it runs AFTER the branch block via the
+    // topological walk.
+    const ir: WorkflowIR = {
+      metadata: { name: 'test', version: 1, createdAt: '', updatedAt: '' },
+      nodes: [
+        {
+          id: 'branch-1',
+          type: 'branch',
+          name: 'Check',
+          position: { x: 0, y: 0 },
+          version: V,
+          provider: P,
+          data: { branches: [{ label: 'yes', condition: 'true' }] },
+        },
+        {
+          id: 'inside',
+          type: 'step',
+          name: 'Inside',
+          position: { x: 0, y: 0 },
+          version: V,
+          provider: P,
+          data: { code: 'return 1;' },
+        },
+        {
+          id: 'after',
+          type: 'step',
+          name: 'After branch',
+          position: { x: 0, y: 0 },
+          version: V,
+          provider: P,
+          data: { code: 'return 2;' },
+        },
+      ],
+      edges: [
+        { id: 'e0', source: 'branch-1', target: 'inside', label: 'yes' },
+        { id: 'e1', source: 'branch-1', target: 'after', label: 'then' },
+      ],
+      entryNodeId: 'branch-1',
+    }
+    const inlineTargets = collectBranchInlineTargets(ir)
+    expect(inlineTargets.has('inside')).toBe(true)
+    expect(inlineTargets.has('after')).toBe(false)
+  })
+
   it('does not include join nodes with in-degree > 1', () => {
     const ir: WorkflowIR = {
       metadata: { name: 'test', version: 1, createdAt: '', updatedAt: '' },


### PR DESCRIPTION
## Summary

Two related branch issues users hit in real workflows:

1. **Single-condition branches blocked.** Validation rejected `if (cond) { do this }` with no else — required `>= 2` branches. Codegen has always handled the no-else case correctly; the block was purely the validation rule.

2. **Continuation after a branch silently dropped.** Connecting a node after a branch produced an unlabeled edge that the codegen discarded. The codegen has always recognized \`then\`-labeled edges as the continuation path (excluded from inline collection, emitted in the topological walk after the branch). The bug was in the canvas: no way to actually create such an edge.

## Changes

- **`validate-workflow.ts`**: drop the \`< 2\` hard error; keep \`< 1\` (zero branches). The "no default/else branch" warning stays — fires for any branch chain whose last arm has a non-empty condition.
- **`node-config-panel.tsx`** (BranchFields): added an "After branch / Continue to" section below the per-branch list. Mirrors the existing \`ForkFields\` and \`TryCatchFields\` "After completion" pattern. Sets the edge label to \`'then'\`.
- **`workflow-store.ts`** (onConnect): a direct canvas drag from a branch's source handle now auto-labels as \`'then'\` (continuation). Per-branch wiring (yes/no/etc.) still belongs in the config panel.

## Test plan

- [x] 2 new \`validate-workflow.test.ts\` cases: accepts single-condition, errors on zero branches
- [x] 1 new \`branch.test.ts\` case: \`then\`-labeled target NOT collected as inline
- [x] 2 new \`generate.test.ts\` cases: single-branch emits \`if\` with no \`else\`; \`then\` continuation appears after the branch's closing brace
- [x] All 1319 tests pass; lint + type-check + build clean
- [ ] Manual: create a workflow with one branch + connect a continuation node via the config panel "Continue to" — confirm generated code has the if-block followed by the continuation step
- [ ] Manual: drag an edge from a branch directly on the canvas — confirm it gets the "then" label automatically