### PR TITLE
fix(canvas): allow branch nodes with a single branch

### DIFF
--- a/apps/web/src/components/canvas/node-config-panel.tsx
+++ b/apps/web/src/components/canvas/node-config-panel.tsx
@@ -53,7 +53,7 @@ export function validateNode(node: WorkflowNode): string[] {
     }
     case 'branch': {
       const branches = (node.data.branches ?? []) as BranchCondition[]
-      if (branches.length < 2) errors.push('At least 2 branches are required')
+      if (branches.length < 1) errors.push('At least 1 branch is required')
       break
     }
     case 'loop': {


### PR DESCRIPTION
Previously branch nodes required at least 2 branches, which was overly restrictive for certain workflow patterns. This change reduces the minimum to 1 branch to support simpler conditional logic.