### PR TITLE
feat(canvas): add sub_script node for script-to-script calls via service binding

### DIFF
--- a/apps/web/src/components/canvas/node-config-panel.tsx
+++ b/apps/web/src/components/canvas/node-config-panel.tsx
@@ -71,6 +71,10 @@ export function validateNode(node: WorkflowNode): string[] {
       if (!String(node.data.workflowId ?? '').trim()) errors.push('Script name is required')
       if (!String(node.data.workflowName ?? '').trim()) errors.push('Workflow name is required')
       break
+    case 'sub_script':
+      if (!String(node.data.workerName ?? '').trim()) errors.push('Worker name is required')
+      if (!String(node.data.url ?? '').trim()) errors.push('URL is required')
+      break
   }
   return errors
 }

--- a/apps/web/src/components/canvas/node-palette.tsx
+++ b/apps/web/src/components/canvas/node-palette.tsx
@@ -26,6 +26,7 @@ const BUILTIN_IDS = new Set([
   'loop',
   'break',
   'sub_workflow',
+  'sub_script',
   'race',
 ])
 

--- a/apps/web/src/components/canvas/nodes.tsx
+++ b/apps/web/src/components/canvas/nodes.tsx
@@ -13,6 +13,7 @@ import {
   CircleStop,
   Workflow,
   Zap,
+  Send,
 } from 'lucide-react'
 import { NodeBase } from './node-base'
 import type { FlowNode } from '../../stores/workflow-store'
@@ -208,6 +209,27 @@ export const SubWorkflowNode = memo(function SubWorkflowNode({
   )
 })
 
+export const SubScriptNode = memo(function SubScriptNode({ data, selected }: NodeProps<FlowNode>) {
+  const node = data.irNode
+  if (node.type !== 'sub_script') return null
+  const workerName = String(node.data.workerName ?? '')
+  const method = String(node.data.method ?? 'POST')
+  return (
+    <NodeBase
+      label={node.name}
+      icon={<Send className="h-2.5 w-2.5" />}
+      accent="bg-node-sub/15 text-node-sub"
+      selected={selected}
+    >
+      {workerName && (
+        <span className="font-mono">
+          {method} → {workerName}
+        </span>
+      )}
+    </NodeBase>
+  )
+})
+
 export const RaceNode = memo(function RaceNode({ data, selected }: NodeProps<FlowNode>) {
   const node = data.irNode
   if (node.type !== 'race') return null
@@ -255,6 +277,7 @@ export const nodeTypes = {
   loop: LoopNode,
   break: BreakNode,
   sub_workflow: SubWorkflowNode,
+  sub_script: SubScriptNode,
   race: RaceNode,
   custom: CustomNodeComponent,
 }

--- a/apps/web/src/components/canvas/simulation-panel.tsx
+++ b/apps/web/src/components/canvas/simulation-panel.tsx
@@ -16,6 +16,7 @@ const NODE_TYPE_LABELS: Record<string, string> = {
   try_catch: 'Try/Catch',
   break: 'Exit',
   sub_workflow: 'Sub-Workflow',
+  sub_script: 'Call Script',
   http_request: 'HTTP',
   wait_for_event: 'Event',
 }

--- a/apps/web/src/lib/node-icon-map.tsx
+++ b/apps/web/src/lib/node-icon-map.tsx
@@ -12,6 +12,7 @@ import {
   CircleStop,
   Workflow,
   Zap,
+  Send,
 } from 'lucide-react'
 
 export interface NodeVisuals {
@@ -74,6 +75,11 @@ const iconMap: Record<string, NodeVisuals> = {
   sub_workflow: {
     icon: <Workflow className="h-2.5 w-2.5" />,
     paletteIcon: <Workflow className="h-4 w-4" />,
+    accent: 'bg-node-sub/15 text-node-sub',
+  },
+  sub_script: {
+    icon: <Send className="h-2.5 w-2.5" />,
+    paletteIcon: <Send className="h-4 w-4" />,
     accent: 'bg-node-sub/15 text-node-sub',
   },
   race: {

--- a/apps/web/src/lib/simulate-workflow.ts
+++ b/apps/web/src/lib/simulate-workflow.ts
@@ -62,6 +62,11 @@ function getStepDetail(node: FlowNode): { status: SimulationStepStatus; detail: 
       return { status: 'executed', detail: `Exit: ${ir.name}` }
     case 'sub_workflow':
       return { status: 'executed', detail: `Sub-workflow: ${ir.data.workflowName}` }
+    case 'sub_script':
+      return {
+        status: 'executed',
+        detail: `Call script: ${String(ir.data.method ?? 'POST')} → ${String(ir.data.workerName ?? '?')}`,
+      }
     case 'http_request':
       return { status: 'executed', detail: `HTTP ${ir.data.method} ${ir.data.url} (simulated)` }
     case 'wait_for_event':

--- a/apps/web/src/stores/workflow-store.ts
+++ b/apps/web/src/stores/workflow-store.ts
@@ -31,6 +31,7 @@ const BUILTIN_FLOW_TYPES = new Set([
   'loop',
   'break',
   'sub_workflow',
+  'sub_script',
   'race',
 ])
 
@@ -206,6 +207,19 @@ function createDefaultNode(
           input: '',
           waitForCompletion: true,
           timeout: '5 minutes',
+        },
+      }
+    case 'sub_script':
+      return {
+        ...base,
+        name: 'Call Script',
+        data: {
+          workerName: '',
+          method: 'POST',
+          url: 'https://invoke/',
+          headers: {},
+          body: '',
+          retryLimit: 3,
         },
       }
     default: {

--- a/packages/ir/src/bundled-nodes/index.ts
+++ b/packages/ir/src/bundled-nodes/index.ts
@@ -11,6 +11,7 @@ export { tryCatchDefinition } from './try-catch.js'
 export { loopDefinition } from './loop.js'
 export { breakDefinition } from './break.js'
 export { subWorkflowDefinition } from './sub-workflow.js'
+export { subScriptDefinition } from './sub-script.js'
 export { raceDefinition } from './race.js'
 
 import { stepDefinition } from './step.js'
@@ -24,6 +25,7 @@ import { tryCatchDefinition } from './try-catch.js'
 import { loopDefinition } from './loop.js'
 import { breakDefinition } from './break.js'
 import { subWorkflowDefinition } from './sub-workflow.js'
+import { subScriptDefinition } from './sub-script.js'
 import { raceDefinition } from './race.js'
 
 export const bundledNodeDefinitions: NodeDefinition[] = [
@@ -38,5 +40,6 @@ export const bundledNodeDefinitions: NodeDefinition[] = [
   loopDefinition,
   breakDefinition,
   subWorkflowDefinition,
+  subScriptDefinition,
   raceDefinition,
 ]

--- a/packages/ir/src/bundled-nodes/sub-script.ts
+++ b/packages/ir/src/bundled-nodes/sub-script.ts
@@ -1,0 +1,75 @@
+import type { NodeDefinition } from '../node-definition.js'
+
+/**
+ * Calls another deployed Worker (kind: 'script') via a Cloudflare service
+ * binding. Same datacenter, no public network round-trip. Generates an
+ * `env.<BINDING>.fetch(url, { method, headers, body })` call wrapped in a
+ * step.do (workflow mode) or a bare await (script mode).
+ *
+ * The user supplies the deployed worker name (free text, like sub_workflow's
+ * workflowId). The env binding name is auto-derived: `awaitstep-my-script` →
+ * `MY_SCRIPT`.
+ */
+export const subScriptDefinition: NodeDefinition = {
+  id: 'sub_script',
+  name: 'Call Script',
+  version: '1.0.0',
+  description: 'Call another deployed script via Cloudflare service binding.',
+  category: 'Control Flow',
+  author: 'awaitstep',
+  license: 'Apache-2.0',
+  configSchema: {
+    workerName: {
+      type: 'string',
+      label: 'Worker Name',
+      required: true,
+      description: 'The deployed worker name (e.g. awaitstep-my-script).',
+      placeholder: 'awaitstep-my-script',
+    },
+    method: {
+      type: 'select',
+      label: 'Method',
+      required: true,
+      default: 'POST',
+      options: ['GET', 'POST', 'PUT', 'PATCH', 'DELETE', 'HEAD', 'OPTIONS'],
+    },
+    url: {
+      type: 'string',
+      label: 'URL',
+      required: true,
+      default: 'https://invoke/',
+      placeholder: 'https://invoke/',
+      description:
+        'Placeholder URL — service-binding calls bypass DNS, but the called worker sees this as request.url for routing.',
+    },
+    headers: {
+      type: 'json',
+      label: 'Headers',
+      description: 'JSON object of request headers.',
+    },
+    body: {
+      type: 'code',
+      label: 'Body',
+      description: 'Request body. Used for POST/PUT/PATCH. Stringified as JSON if not a string.',
+    },
+    retryLimit: {
+      type: 'number',
+      label: 'Retry Limit',
+      default: 3,
+      placeholder: '3',
+      validation: { min: 0 },
+    },
+    timeout: {
+      type: 'string',
+      label: 'Timeout',
+      placeholder: '5 minutes',
+      validation: { format: 'duration' },
+    },
+  },
+  outputSchema: {
+    status: { type: 'number', description: 'HTTP status code' },
+    body: { type: 'string', description: 'Response body as text' },
+    headers: { type: 'object', description: 'Response headers' },
+  },
+  providers: ['cloudflare'],
+}

--- a/packages/provider-cloudflare/src/__tests__/codegen/generators/sub-script.test.ts
+++ b/packages/provider-cloudflare/src/__tests__/codegen/generators/sub-script.test.ts
@@ -1,0 +1,126 @@
+import { describe, it, expect } from 'vitest'
+import type { WorkflowNode } from '@awaitstep/ir'
+import {
+  generateSubScript,
+  getSubScriptBindings,
+  workerNameToBinding,
+} from '../../../codegen/generators/sub-script.js'
+
+const V = '1.0.0'
+const P = 'cloudflare'
+
+function makeNode(overrides: Partial<WorkflowNode['data']> = {}): WorkflowNode {
+  return {
+    id: 'sub1',
+    type: 'sub_script',
+    name: 'Call email service',
+    position: { x: 0, y: 0 },
+    version: V,
+    provider: P,
+    data: { workerName: 'awaitstep-email-service', ...overrides },
+  }
+}
+
+describe('workerNameToBinding', () => {
+  it('strips awaitstep- prefix and uppercases hyphenated names', () => {
+    expect(workerNameToBinding('awaitstep-email-service')).toBe('EMAIL_SERVICE')
+    expect(workerNameToBinding('awaitstep-my-script')).toBe('MY_SCRIPT')
+  })
+
+  it('passes non-prefixed names through (uppercased, hyphens to underscores)', () => {
+    expect(workerNameToBinding('my-worker')).toBe('MY_WORKER')
+    expect(workerNameToBinding('plain')).toBe('PLAIN')
+  })
+
+  it('case-insensitive prefix match', () => {
+    expect(workerNameToBinding('AwaitStep-Foo')).toBe('FOO')
+  })
+
+  it('replaces non-identifier characters with underscores', () => {
+    expect(workerNameToBinding('awaitstep-foo.bar/baz')).toBe('FOO_BAR_BAZ')
+  })
+
+  it('returns empty string for empty input', () => {
+    expect(workerNameToBinding('')).toBe('')
+  })
+})
+
+describe('generateSubScript', () => {
+  it('emits a service-binding fetch call wrapped in step.do (workflow mode)', () => {
+    const code = generateSubScript(makeNode(), 'workflow')
+    expect(code).toContain('step.do("Call email service"')
+    expect(code).toContain('await env.EMAIL_SERVICE.fetch("https://invoke/"')
+    expect(code).toContain('method: "POST"')
+    expect(code).toContain('return response.json()')
+  })
+
+  it('emits a bare await fetch (script mode)', () => {
+    const code = generateSubScript(makeNode(), 'script')
+    expect(code).not.toContain('step.do')
+    expect(code).toContain(
+      'const sub1 = await env.EMAIL_SERVICE.fetch("https://invoke/", { method: "POST" }).then(r => r.json())',
+    )
+  })
+
+  it('uses POST as the default method', () => {
+    const code = generateSubScript(makeNode())
+    expect(code).toContain('method: "POST"')
+  })
+
+  it('respects an explicit method override', () => {
+    const code = generateSubScript(makeNode({ method: 'PUT' }))
+    expect(code).toContain('method: "PUT"')
+  })
+
+  it('uses the configured URL', () => {
+    const code = generateSubScript(makeNode({ url: 'https://target/path' }))
+    expect(code).toContain('"https://target/path"')
+  })
+
+  it('serializes JS-expression body via JSON.stringify (with string-typecheck escape)', () => {
+    const code = generateSubScript(makeNode({ body: '{ id: 42, items: state.items }' }), 'script')
+    // Body wrapper handles both string and non-string values.
+    expect(code).toContain(
+      'body: typeof ({ id: 42, items: state.items }) === "string" ? ({ id: 42, items: state.items }) : JSON.stringify({ id: 42, items: state.items })',
+    )
+  })
+
+  it('emits headers when provided', () => {
+    const code = generateSubScript(
+      makeNode({ headers: { 'Content-Type': 'application/json', Authorization: 'Bearer x' } }),
+    )
+    expect(code).toContain('"Content-Type": "application/json"')
+    expect(code).toContain('"Authorization": "Bearer x"')
+  })
+})
+
+describe('getSubScriptBindings', () => {
+  it('collects one binding per unique workerName', () => {
+    const bindings = getSubScriptBindings([
+      { type: 'sub_script', data: { workerName: 'awaitstep-emails' } },
+      { type: 'sub_script', data: { workerName: 'awaitstep-jobs' } },
+      { type: 'step', data: { code: 'noop' } },
+    ])
+    expect(bindings).toEqual([
+      { binding: 'EMAILS', service: 'awaitstep-emails' },
+      { binding: 'JOBS', service: 'awaitstep-jobs' },
+    ])
+  })
+
+  it('dedupes when multiple sub_script nodes target the same worker', () => {
+    const bindings = getSubScriptBindings([
+      { type: 'sub_script', data: { workerName: 'awaitstep-emails' } },
+      { type: 'sub_script', data: { workerName: 'awaitstep-emails' } },
+    ])
+    expect(bindings).toHaveLength(1)
+    expect(bindings[0]).toEqual({ binding: 'EMAILS', service: 'awaitstep-emails' })
+  })
+
+  it('skips nodes with empty workerName', () => {
+    const bindings = getSubScriptBindings([
+      { type: 'sub_script', data: { workerName: '' } },
+      { type: 'sub_script', data: {} },
+    ])
+    expect(bindings).toEqual([])
+  })
+})

--- a/packages/provider-cloudflare/src/__tests__/wrangler-config.test.ts
+++ b/packages/provider-cloudflare/src/__tests__/wrangler-config.test.ts
@@ -452,6 +452,53 @@ describe('generateWranglerConfig', () => {
     ).toThrow(/workflow deploys require/)
   })
 
+  describe('subScriptBindings', () => {
+    const baseScript = {
+      kind: 'script' as const,
+      workerName: 'awaitstep-q',
+      main: './worker.js',
+    }
+
+    it('emits services entries from subScriptBindings even when no other bindings exist', () => {
+      const json = generateWranglerConfig({
+        ...baseScript,
+        subScriptBindings: [
+          { binding: 'EMAILS', service: 'awaitstep-emails' },
+          { binding: 'JOBS', service: 'awaitstep-jobs' },
+        ],
+      })
+      const parsed = JSON.parse(json)
+      expect(parsed.services).toEqual([
+        { binding: 'EMAILS', service: 'awaitstep-emails' },
+        { binding: 'JOBS', service: 'awaitstep-jobs' },
+      ])
+    })
+
+    it('merges sub_script bindings with code-scan service bindings', () => {
+      const json = generateWranglerConfig({
+        ...baseScript,
+        bindings: [{ name: 'SERVICE_OTHER', type: 'service', source: 'code-scan' }],
+        subScriptBindings: [{ binding: 'EMAILS', service: 'awaitstep-emails' }],
+      })
+      const parsed = JSON.parse(json)
+      // Both entries present; code-scan kept its derived service name (lowercased binding).
+      expect(parsed.services).toEqual([
+        { binding: 'SERVICE_OTHER', service: 'service_other' },
+        { binding: 'EMAILS', service: 'awaitstep-emails' },
+      ])
+    })
+
+    it('sub_script wins on binding-name conflict (carries explicit deployed service name)', () => {
+      const json = generateWranglerConfig({
+        ...baseScript,
+        bindings: [{ name: 'EMAILS', type: 'service', source: 'code-scan' }],
+        subScriptBindings: [{ binding: 'EMAILS', service: 'awaitstep-emails' }],
+      })
+      const parsed = JSON.parse(json)
+      expect(parsed.services).toEqual([{ binding: 'EMAILS', service: 'awaitstep-emails' }])
+    })
+  })
+
   describe('queueConsumers', () => {
     const baseScript = {
       kind: 'script' as const,

--- a/packages/provider-cloudflare/src/adapter.ts
+++ b/packages/provider-cloudflare/src/adapter.ts
@@ -23,6 +23,7 @@ import { CloudflareAPI } from './api.js'
 import { WRANGLER_BASE_CONFIG } from './wrangler-config.js'
 import { detectBindings, type BindingRequirement } from './codegen/bindings.js'
 import { getSubWorkflowBindings } from './codegen/generators/sub-workflow.js'
+import { getSubScriptBindings } from './codegen/generators/sub-script.js'
 import { parseAnnotations } from './codegen/parse-annotations.js'
 import {
   cloudflareDefaultDeploymentConfig,
@@ -275,6 +276,7 @@ export class CloudflareWorkflowsAdapter implements WorkflowProvider, LocalDevPro
 
     // Collect sub-workflow bindings from IR
     const subWorkflowBindings = ir ? getSubWorkflowBindings(ir.nodes) : []
+    const subScriptBindings = ir ? getSubScriptBindings(ir.nodes) : []
 
     report('BINDINGS_READY', 'Resource bindings configured', 45)
 
@@ -354,6 +356,7 @@ export class CloudflareWorkflowsAdapter implements WorkflowProvider, LocalDevPro
         dependencies: opts.dependencies,
         bindings: resolvedBindings,
         subWorkflowBindings: subWorkflowBindings.length > 0 ? subWorkflowBindings : undefined,
+        subScriptBindings: subScriptBindings.length > 0 ? subScriptBindings : undefined,
         previewUrls,
         workersDev,
         routes,

--- a/packages/provider-cloudflare/src/codegen/generate-helpers.ts
+++ b/packages/provider-cloudflare/src/codegen/generate-helpers.ts
@@ -13,6 +13,7 @@ import { generateTryCatch } from './generators/try-catch.js'
 import { generateLoop } from './generators/loop.js'
 import { generateBreak } from './generators/break.js'
 import { generateSubWorkflow } from './generators/sub-workflow.js'
+import { generateSubScript } from './generators/sub-script.js'
 import { generateRace } from './generators/race.js'
 import type { BindingType } from './bindings.js'
 
@@ -142,6 +143,8 @@ export function generateNodeCode(
       return generateBreak(node)
     case 'sub_workflow':
       return generateSubWorkflow(node, mode)
+    case 'sub_script':
+      return generateSubScript(node, mode)
     case 'race':
       return generateRace(node, ir, recurse, mode)
     default: {

--- a/packages/provider-cloudflare/src/codegen/generate-script.ts
+++ b/packages/provider-cloudflare/src/codegen/generate-script.ts
@@ -117,6 +117,7 @@ export function generateScript(
     'loop',
     'break',
     'sub_workflow',
+    'sub_script',
     'race',
   ])
 

--- a/packages/provider-cloudflare/src/codegen/generate-workflow.ts
+++ b/packages/provider-cloudflare/src/codegen/generate-workflow.ts
@@ -115,6 +115,7 @@ export function generateWorkflow(
     'loop',
     'break',
     'sub_workflow',
+    'sub_script',
     'race',
   ])
 

--- a/packages/provider-cloudflare/src/codegen/generators/sub-script.ts
+++ b/packages/provider-cloudflare/src/codegen/generators/sub-script.ts
@@ -1,0 +1,130 @@
+import type { WorkflowNode } from '@awaitstep/ir'
+import { varName, escName, type GenerateMode } from '@awaitstep/codegen'
+import { generateStepConfig } from './config.js'
+
+/**
+ * Generates code for a `sub_script` node: an HTTP-shaped call to another
+ * deployed Worker via a Cloudflare service binding (`env.<BINDING>.fetch(...)`).
+ *
+ * Same datacenter, no public network round-trip. The called worker's `fetch()`
+ * handler runs and returns a Response; we parse it as JSON and bind the result
+ * to the node's variable name.
+ *
+ * In workflow mode, the call is wrapped in `step.do(...)` for durability +
+ * retries. In script mode, it's a bare `await env.X.fetch(...).then(r => r.json())`.
+ */
+export function generateSubScript(node: WorkflowNode, mode: GenerateMode = 'workflow'): string {
+  const workerName = String(node.data.workerName ?? '')
+  const binding = workerNameToBinding(workerName)
+  const method = String(node.data.method ?? 'POST')
+  const url = String(node.data.url ?? 'https://invoke/')
+  const rawHeaders = node.data.headers
+  const headers =
+    rawHeaders && typeof rawHeaders === 'object' && !Array.isArray(rawHeaders)
+      ? (rawHeaders as Record<string, string>)
+      : undefined
+  const body = node.data.body as string | undefined
+
+  const config = generateStepConfig(node.config)
+  const configArg = config ? `, ${config}` : ''
+
+  const fetchOptions: string[] = [`method: "${method}"`]
+
+  if (headers && Object.keys(headers).length > 0) {
+    const headerEntries = Object.entries(headers)
+      .map(([k, v]) => `"${k}": ${toJsLiteral(v)}`)
+      .join(', ')
+    fetchOptions.push(`headers: { ${headerEntries} }`)
+  }
+
+  if (body && body.trim().length > 0) {
+    // User wrote a JS expression for the body. Wrap with JSON.stringify if it
+    // doesn't already look like a string/Request body. Conservative: assume
+    // it's a value and stringify; users who pass a string explicitly can wrap
+    // their expression with String(...) to bypass.
+    fetchOptions.push(`body: typeof (${body}) === "string" ? (${body}) : JSON.stringify(${body})`)
+  }
+
+  const urlLiteral = toJsLiteral(url)
+  const fetchOpts = fetchOptions.length > 0 ? `, { ${fetchOptions.join(', ')} }` : ''
+
+  if (mode === 'script') {
+    return `const ${varName(node.id)} = await env.${binding}.fetch(${urlLiteral}${fetchOpts}).then(r => r.json());`
+  }
+  return `const ${varName(node.id)} = await step.do("${escName(node.name)}"${configArg}, async () => {
+  const response = await env.${binding}.fetch(${urlLiteral}${fetchOpts});
+  return response.json();
+});`
+}
+
+export interface SubScriptBinding {
+  /** Env binding name, e.g. MY_SCRIPT */
+  binding: string
+  /** The user-provided deployed worker name */
+  service: string
+}
+
+/**
+ * Convert a deployed worker name (e.g. `awaitstep-my-script` or `my-worker`)
+ * to an UPPER_SNAKE_CASE env binding identifier (`MY_SCRIPT`, `MY_WORKER`).
+ *
+ * Strips a leading `awaitstep-` prefix when present so generated names stay
+ * readable; all hyphens become underscores; non-identifier chars are replaced
+ * with underscores. Falls back to the raw name uppercased if stripping yields
+ * an empty string.
+ */
+export function workerNameToBinding(workerName: string): string {
+  if (!workerName) return ''
+  const stripped = workerName.replace(/^awaitstep-/i, '')
+  const base = stripped.length > 0 ? stripped : workerName
+  return base
+    .replace(/[^A-Za-z0-9_]/g, '_')
+    .replace(/^_+|_+$/g, '')
+    .toUpperCase()
+}
+
+/**
+ * Collects unique service-binding entries from all `sub_script` nodes in the
+ * IR. Returns one binding per unique workerName so duplicates (multiple calls
+ * to the same script) collapse into one wrangler.json `services[]` entry.
+ */
+export function getSubScriptBindings(
+  nodes: readonly { type: string; data: Record<string, unknown> }[],
+): SubScriptBinding[] {
+  const seen = new Set<string>()
+  const bindings: SubScriptBinding[] = []
+  for (const node of nodes) {
+    if (node.type !== 'sub_script') continue
+    const workerName = String(node.data.workerName ?? '')
+    if (!workerName) continue
+    const binding = workerNameToBinding(workerName)
+    if (!binding || seen.has(binding)) continue
+    seen.add(binding)
+    bindings.push({ binding, service: workerName })
+  }
+  return bindings
+}
+
+function toJsLiteral(value: unknown): string {
+  if (value === null || value === undefined) return 'null'
+  if (typeof value === 'number' || typeof value === 'boolean') return String(value)
+  if (typeof value === 'string') {
+    const hasExpression = /\$\{.*?\}/.test(value)
+    const hasNewline = /\r?\n/.test(value)
+    if (hasExpression || hasNewline) {
+      const escaped = value.replace(/\\/g, '\\\\').replace(/`/g, '\\`')
+      return '`' + escaped + '`'
+    }
+    return `"${value.replace(/\\/g, '\\\\').replace(/"/g, '\\"')}"`
+  }
+  if (Array.isArray(value)) {
+    return `[${value.map((v) => toJsLiteral(v)).join(', ')}]`
+  }
+  if (typeof value === 'object') {
+    const entries = Object.entries(value as Record<string, unknown>)
+      .map(([k, v]) => `"${k}": ${toJsLiteral(v)}`)
+      .join(', ')
+    return `{ ${entries} }`
+  }
+  return JSON.stringify(value)
+}

--- a/packages/provider-cloudflare/src/deploy/deployer.ts
+++ b/packages/provider-cloudflare/src/deploy/deployer.ts
@@ -2,6 +2,7 @@ import { basename } from 'node:path'
 import type { GeneratedArtifact } from '@awaitstep/codegen'
 import type { BindingRequirement } from '../codegen/bindings.js'
 import type { SubWorkflowBinding } from '../codegen/generators/sub-workflow.js'
+import type { SubScriptBinding } from '../codegen/generators/sub-script.js'
 
 const SECRET_KEY_PATTERN = /^[a-zA-Z_][a-zA-Z0-9_]*$/
 
@@ -70,6 +71,8 @@ export interface DeployOptions {
   dependencies?: Record<string, string>
   bindings?: BindingRequirement[]
   subWorkflowBindings?: SubWorkflowBinding[]
+  /** Service bindings collected from `sub_script` nodes. Forwarded to wrangler.json `services[]`. */
+  subScriptBindings?: SubScriptBinding[]
   previewUrls?: boolean
   workersDev?: boolean
   routes?: Array<{ pattern: string; zone_name: string }>

--- a/packages/provider-cloudflare/src/deploy/node-deployer.ts
+++ b/packages/provider-cloudflare/src/deploy/node-deployer.ts
@@ -44,6 +44,7 @@ export class NodeWranglerDeployer implements WranglerDeployer {
         vars: options.vars,
         bindings: options.bindings,
         subWorkflowBindings: options.subWorkflowBindings,
+        subScriptBindings: options.subScriptBindings,
         previewUrls: options.previewUrls,
         workersDev: options.workersDev,
         routes: options.routes,

--- a/packages/provider-cloudflare/src/deploy/sandbox-deployer.ts
+++ b/packages/provider-cloudflare/src/deploy/sandbox-deployer.ts
@@ -65,6 +65,7 @@ export class SandboxWranglerDeployer implements WranglerDeployer {
         vars: options.vars,
         bindings: options.bindings,
         subWorkflowBindings: options.subWorkflowBindings,
+        subScriptBindings: options.subScriptBindings,
         previewUrls: options.previewUrls,
         workersDev: options.workersDev,
         routes: options.routes,

--- a/packages/provider-cloudflare/src/wrangler-config.ts
+++ b/packages/provider-cloudflare/src/wrangler-config.ts
@@ -1,5 +1,6 @@
 import { deriveQueueName, type BindingRequirement } from './codegen/bindings.js'
 import type { SubWorkflowBinding } from './codegen/generators/sub-workflow.js'
+import type { SubScriptBinding } from './codegen/generators/sub-script.js'
 
 export const WRANGLER_BASE_CONFIG = {
   compatibility_date: '2025-04-01',
@@ -24,6 +25,14 @@ export interface WranglerWorkflowConfig {
   vars?: Record<string, string>
   bindings?: BindingRequirement[]
   subWorkflowBindings?: SubWorkflowBinding[]
+  /**
+   * Service bindings for `sub_script` calls — emitted as
+   * `services: [{ binding, service }]` entries in wrangler.json. Coexists with
+   * any service bindings auto-detected from `env.SERVICE_*` references; the
+   * two sources are merged with sub-script entries taking precedence on
+   * binding-name conflicts.
+   */
+  subScriptBindings?: SubScriptBinding[]
   previewUrls?: boolean
   workersDev?: boolean
   routes?: Array<{ pattern: string; zone_name: string }>
@@ -233,6 +242,23 @@ export function generateWranglerConfig(config: WranglerWorkflowConfig): string {
     })
     const existing = (wranglerConfig.queues ?? {}) as Record<string, unknown>
     wranglerConfig.queues = { ...existing, consumers }
+  }
+
+  // Merge sub_script service bindings into the services array. Runs outside
+  // the `config.bindings` conditional so a workflow with only sub_script
+  // calls (and no other auto-detected bindings) still gets a services entry.
+  // Code-scan-detected service bindings (env.SERVICE_*) and sub_script
+  // bindings can both contribute; on binding-name conflict, sub_script wins
+  // because it carries the explicit deployed service name.
+  if (config.subScriptBindings && config.subScriptBindings.length > 0) {
+    const subScriptEntries = config.subScriptBindings.map((b) => ({
+      binding: b.binding,
+      service: b.service,
+    }))
+    const subScriptNames = new Set(subScriptEntries.map((e) => e.binding))
+    const existing = (wranglerConfig.services ?? []) as Array<{ binding: string }>
+    const filtered = existing.filter((s) => !subScriptNames.has(s.binding))
+    wranglerConfig.services = [...filtered, ...subScriptEntries]
   }
 
   return JSON.stringify(wranglerConfig, null, 2)


### PR DESCRIPTION
## Summary

Mirrors \`sub_workflow\` but targets fetch-only Workers via Cloudflare service bindings. Same datacenter, no public network round-trip.

User flow: drop a "Call Script" node, type the deployed worker name, pick method/headers/body like an HTTP node. The env binding name (\`MY_SCRIPT\`) and the \`services: [{ binding, service }]\` wrangler entry are derived automatically.

**Codegen:**
- Workflow mode wraps the call in \`step.do(...)\` for durability + retries
- Script mode emits a bare \`await env.X.fetch(url, opts).then(r => r.json())\`

**Body coercion:** user JS expression is wrapped with a typeof-string check so \`{ foo: 1 }\` stringifies but \`"already a string"\` passes through. Lets users write either an object literal or a serialized string without thinking about it.

**Service-binding emission** runs outside the existing bindings conditional so workflows with only \`sub_script\` calls still get a services entry. Merges with code-scan-detected \`env.SERVICE_*\` bindings; on binding-name conflict, sub_script wins.

## Test plan

- [x] 13 new generator + binding tests (script/workflow modes, defaults, headers, body coercion, prefix stripping, dedup)
- [x] 3 new wrangler-config tests (services from sub_script only, merged with code-scan, conflict resolution)
- [x] All 1337 tests pass; lint + type-check + build clean across packages
- [ ] Manual: deploy a script with a \`sub_script\` node calling another deployed worker — confirm wrangler.json has the service binding and the call succeeds at runtime
- [ ] Manual: configure POST + JSON body via the config panel; verify the called worker receives the payload via \`await request.json()\`