### PR TITLE
fix(codegen): normalize queue names to CF validation rules

### DIFF
--- a/packages/provider-cloudflare/src/__tests__/adapter.test.ts
+++ b/packages/provider-cloudflare/src/__tests__/adapter.test.ts
@@ -283,6 +283,31 @@ describe('buildQueueConsumers', () => {
     expect(result).toEqual([{ queue: 'emails', maxBatchSize: 5 }, { queue: 'jobs' }])
   })
 
+  it('emits CF-valid queue name (snake_case function → kebab-case queue)', () => {
+    const triggerCode = `
+@queue function marktplaats_processor(b, e, c) { msg.ack() }
+`
+    const result = buildQueueConsumers(triggerCode, undefined)
+    expect(result).toEqual([{ queue: 'marktplaats-processor' }])
+    expect(result![0]!.queue).toMatch(/^[a-z0-9-]+$/)
+  })
+
+  it('deployment override matches by either JS function name or CF queue name', () => {
+    const triggerCode = `
+@queue function marktplaats_processor(b, e, c) { msg.ack() }
+`
+    // Override keyed by JS function name (what user might naturally type)
+    const byJsName = buildQueueConsumers(triggerCode, {
+      queueConsumers: [{ queue: 'marktplaats_processor', maxBatchSize: 1 }],
+    })
+    expect(byJsName).toEqual([{ queue: 'marktplaats-processor', maxBatchSize: 1 }])
+    // Override keyed by CF queue name (what shows up in wrangler.json)
+    const byCFName = buildQueueConsumers(triggerCode, {
+      queueConsumers: [{ queue: 'marktplaats-processor', maxBatchSize: 1 }],
+    })
+    expect(byCFName).toEqual([{ queue: 'marktplaats-processor', maxBatchSize: 1 }])
+  })
+
   it('returns undefined on annotation parse error (already surfaced by generate)', () => {
     const triggerCode = `@fetch function notHandler() {}`
     expect(buildQueueConsumers(triggerCode, undefined)).toBeUndefined()

--- a/packages/provider-cloudflare/src/__tests__/codegen/bindings.test.ts
+++ b/packages/provider-cloudflare/src/__tests__/codegen/bindings.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest'
-import { detectBindings, deriveQueueName } from '../../codegen/bindings.js'
+import { detectBindings, deriveQueueName, toCFQueueName } from '../../codegen/bindings.js'
 import type { WorkflowIR, WorkflowNode } from '@awaitstep/ir'
 
 describe('deriveQueueName', () => {
@@ -21,6 +21,82 @@ describe('deriveQueueName', () => {
     // Defensive: shouldn't be called with non-queue bindings, but if so,
     // returns a sensible value rather than throwing.
     expect(deriveQueueName('FOO_BAR')).toBe('foo_bar')
+  })
+})
+
+describe('toCFQueueName', () => {
+  it('passes already-valid names through unchanged', () => {
+    expect(toCFQueueName('emails')).toBe('emails')
+    expect(toCFQueueName('marktplaats-processor')).toBe('marktplaats-processor')
+    expect(toCFQueueName('a1b2c3')).toBe('a1b2c3')
+  })
+
+  it('converts snake_case to kebab-case', () => {
+    expect(toCFQueueName('marktplaats_processor')).toBe('marktplaats-processor')
+    expect(toCFQueueName('foo_bar_baz')).toBe('foo-bar-baz')
+  })
+
+  it('converts camelCase to kebab-case', () => {
+    expect(toCFQueueName('marktplaatsProcessor')).toBe('marktplaats-processor')
+    expect(toCFQueueName('myQueue123')).toBe('my-queue123')
+  })
+
+  it('lowercases everything', () => {
+    expect(toCFQueueName('MARKTPLAATS_PROCESSOR')).toBe('marktplaats-processor')
+    expect(toCFQueueName('Foo')).toBe('foo')
+  })
+
+  it('replaces other special characters with hyphens', () => {
+    expect(toCFQueueName('foo.bar/baz')).toBe('foo-bar-baz')
+    expect(toCFQueueName('foo bar')).toBe('foo-bar')
+  })
+
+  it('collapses runs of hyphens', () => {
+    expect(toCFQueueName('foo--bar')).toBe('foo-bar')
+    expect(toCFQueueName('foo___bar')).toBe('foo-bar')
+  })
+
+  it('trims leading and trailing hyphens', () => {
+    expect(toCFQueueName('_foo_')).toBe('foo')
+    expect(toCFQueueName('---bar---')).toBe('bar')
+  })
+
+  it('returns empty string for empty input', () => {
+    expect(toCFQueueName('')).toBe('')
+  })
+
+  it('produces only [a-z0-9-] characters (CF validation rule)', () => {
+    const samples = [
+      'foo_bar',
+      'fooBar',
+      'FOO_BAR',
+      'foo.bar/baz space',
+      'marktplaats_processor',
+      'queue123',
+    ]
+    for (const s of samples) {
+      const result = toCFQueueName(s)
+      expect(result).toMatch(/^[a-z0-9-]+$/)
+    }
+  })
+
+  it('producer + consumer derivations agree on the same CF queue name', () => {
+    // Producer side: env.QUEUE_MARKTPLAATS_PROCESSOR → derive JS identifier → normalize for CF.
+    const producerCF = toCFQueueName(deriveQueueName('QUEUE_MARKTPLAATS_PROCESSOR'))
+    // Consumer side: @queue function marktplaats_processor → directly normalize.
+    const consumerCF = toCFQueueName('marktplaats_processor')
+    expect(producerCF).toBe('marktplaats-processor')
+    expect(consumerCF).toBe('marktplaats-processor')
+    expect(producerCF).toBe(consumerCF)
+  })
+
+  it('camelCase function name aligns with UPPER_SNAKE binding when both follow convention', () => {
+    // Function: @queue function marktplaatsProcessor → marktplaats-processor
+    // Binding:  env.QUEUE_MARKTPLAATS_PROCESSOR → marktplaats-processor
+    expect(toCFQueueName('marktplaatsProcessor')).toBe('marktplaats-processor')
+    expect(toCFQueueName(deriveQueueName('QUEUE_MARKTPLAATS_PROCESSOR'))).toBe(
+      'marktplaats-processor',
+    )
   })
 })
 

--- a/packages/provider-cloudflare/src/__tests__/codegen/generate-script.test.ts
+++ b/packages/provider-cloudflare/src/__tests__/codegen/generate-script.test.ts
@@ -451,6 +451,29 @@ describe('generateScript — annotation mode (@fetch / @queue)', () => {
     expect(code).toContain('msg.ack()')
   })
 
+  it('switch case label uses CF-valid queue name (snake_case → kebab-case)', () => {
+    const triggerCode = `
+@queue function marktplaats_processor(batch, env, ctx) {
+  for (const msg of batch.messages) msg.ack()
+}
+`
+    const code = generateScript(trivialIR, { triggerCode })
+    // Case label uses the kebab-case CF queue name, NOT the snake_case JS function name.
+    expect(code).toContain('case "marktplaats-processor":')
+    expect(code).not.toContain('case "marktplaats_processor":')
+  })
+
+  it('switch case label converts camelCase function names to kebab-case', () => {
+    const triggerCode = `
+@queue function userEvents(batch, env, ctx) {
+  for (const msg of batch.messages) msg.ack()
+}
+`
+    const code = generateScript(trivialIR, { triggerCode })
+    expect(code).toContain('case "user-events":')
+    expect(code).not.toContain('case "userEvents":')
+  })
+
   it('emits multiple @queue handlers as switch cases', () => {
     const triggerCode = `
 @fetch function handler(request, env, ctx) { return new Response("ok") }

--- a/packages/provider-cloudflare/src/__tests__/codegen/parse-annotations.test.ts
+++ b/packages/provider-cloudflare/src/__tests__/codegen/parse-annotations.test.ts
@@ -82,6 +82,24 @@ describe('parseAnnotations — strict mode @fetch', () => {
 })
 
 describe('parseAnnotations — strict mode @queue', () => {
+  it('attaches a CF-valid queueName (lowercase + hyphens) to each queue handler', () => {
+    const source = `
+@queue function marktplaats_processor(b, e, c) { msg.ack() }
+@queue function userEvents(b, e, c) { msg.ack() }
+@queue function simple(b, e, c) { msg.ack() }
+`
+    const result = expectStrict(source)
+    expect(result.queueHandlers.map((h) => ({ name: h.name, queueName: h.queueName }))).toEqual([
+      { name: 'marktplaats_processor', queueName: 'marktplaats-processor' },
+      { name: 'userEvents', queueName: 'user-events' },
+      { name: 'simple', queueName: 'simple' },
+    ])
+    // Belt-and-suspenders: every queueName matches CF's validation regex.
+    for (const h of result.queueHandlers) {
+      expect(h.queueName).toMatch(/^[a-z0-9-]+$/)
+    }
+  })
+
   it('extracts a single @queue handler', () => {
     const source = `@queue function emails(batch, env, ctx) {
   for (const msg of batch.messages) msg.ack()

--- a/packages/provider-cloudflare/src/__tests__/wrangler-config.test.ts
+++ b/packages/provider-cloudflare/src/__tests__/wrangler-config.test.ts
@@ -508,6 +508,21 @@ describe('generateWranglerConfig', () => {
       expect(parsed.queues.consumers).toEqual([{ queue: 'emails' }])
     })
 
+    it('producer queue name converts underscores to hyphens for CF validation', () => {
+      // CF rule: queue names must be lowercase alphanumeric + hyphens only.
+      // QUEUE_MARKTPLAATS_PROCESSOR → marktplaats-processor (NOT marktplaats_processor).
+      const json = generateWranglerConfig({
+        ...baseScript,
+        bindings: [{ name: 'QUEUE_MARKTPLAATS_PROCESSOR', type: 'queue', source: 'code-scan' }],
+      })
+      const parsed = JSON.parse(json)
+      expect(parsed.queues.producers).toEqual([
+        { binding: 'QUEUE_MARKTPLAATS_PROCESSOR', queue: 'marktplaats-processor' },
+      ])
+      // Belt-and-suspenders: assert the queue name passes CF's validation regex.
+      expect(parsed.queues.producers[0].queue).toMatch(/^[a-z0-9-]+$/)
+    })
+
     it('producer queue name strips QUEUE_ prefix so it matches @queue annotation default', () => {
       // No resourceId override: producer derives the queue name from the binding
       // name. Must align with deriveQueueName() so that `env.QUEUE_EMAILS.send(...)`

--- a/packages/provider-cloudflare/src/adapter.ts
+++ b/packages/provider-cloudflare/src/adapter.ts
@@ -501,21 +501,34 @@ export function buildQueueConsumers(
     }>
   | undefined {
   if (!triggerCode) return undefined
-  let handlers: Array<{ name: string; config?: Record<string, string | number | boolean> }>
+  let handlers: Array<{
+    /** JS function identifier — used to match deployment config overrides. */
+    name: string
+    /** CF-valid queue name — used in the wrangler `queue` field. */
+    queueName: string
+    config?: Record<string, string | number | boolean>
+  }>
   try {
     const parsed = parseAnnotations(triggerCode)
     if (parsed.mode !== 'strict' || parsed.queueHandlers.length === 0) return undefined
-    handlers = parsed.queueHandlers.map((q) => ({ name: q.name, config: q.config }))
+    handlers = parsed.queueHandlers.map((q) => ({
+      name: q.name,
+      queueName: q.queueName ?? q.name,
+      config: q.config,
+    }))
   } catch {
     return undefined
   }
 
-  const overrides = new Map(
+  // Deployment-config overrides may be keyed by either the JS function name
+  // or the CF queue name — try both so users can write either form in the
+  // queueConsumers field of the deployment config.
+  const overridesByJsName = new Map(
     (deploymentConfig?.queueConsumers ?? []).map((c) => [c.queue, c] as const),
   )
-  return handlers.map(({ name, config }) => {
-    const override = overrides.get(name)
-    const merged: Record<string, unknown> = { queue: name }
+  return handlers.map(({ name, queueName, config }) => {
+    const override = overridesByJsName.get(name) ?? overridesByJsName.get(queueName)
+    const merged: Record<string, unknown> = { queue: queueName }
     // Layer (2): inline @config block.
     if (config) {
       for (const [k, v] of Object.entries(config)) merged[k] = v

--- a/packages/provider-cloudflare/src/codegen/bindings.ts
+++ b/packages/provider-cloudflare/src/codegen/bindings.ts
@@ -23,20 +23,58 @@ export interface BindingRequirement {
 }
 
 /**
- * Derives the canonical queue name from a `QUEUE_*` binding identifier.
+ * Derives a JS identifier from a `QUEUE_*` binding name. Used by the
+ * "+ Consume" snippet in the bindings panel — produces a name suitable
+ * for a JS function declaration (`@queue function <name>(...)`).
  *
  * - `QUEUE_EMAILS` → `emails`
- * - `QUEUE_JOBS` → `jobs`
+ * - `QUEUE_FOO_BAR` → `foo_bar` (keeps underscores — valid JS identifier)
  * - bare `QUEUE` → `queue`
  *
- * Used in two places that MUST agree, otherwise producer and consumer end
- * up wired to different CF queues:
- * - `generateWranglerConfig` producer derivation (`queues.producers[].queue`)
- * - `@queue function NAME(...)` annotation suggestion in the bindings panel
+ * Note: this is NOT the final CF queue name. CF requires lowercase
+ * alphanumeric + hyphens only, with no underscores. Pipe the result
+ * through `toCFQueueName` for the wrangler.json `queue` field.
  */
 export function deriveQueueName(bindingName: string): string {
   const stripped = bindingName.replace(/^QUEUE_?/i, '')
   return (stripped || bindingName).toLowerCase()
+}
+
+/**
+ * Normalizes any input string into a Cloudflare-valid queue name.
+ * CF rule (from wrangler validation): "Queue names can only contain
+ * hyphens & alphanumeric lowercase letters."
+ *
+ * Conversion:
+ * - Splits camelCase/PascalCase boundaries with hyphens
+ * - Replaces underscores with hyphens
+ * - Replaces any other non-`[a-z0-9-]` char with hyphens
+ * - Collapses runs of hyphens
+ * - Trims leading/trailing hyphens
+ * - Lowercases the result
+ *
+ * Examples:
+ * - `marktplaats_processor` → `marktplaats-processor`
+ * - `marktplaatsProcessor` → `marktplaats-processor`
+ * - `MARKTPLAATS_PROCESSOR` → `marktplaats-processor`
+ * - `simple` → `simple`
+ *
+ * Used in three places that MUST agree on the same name, otherwise
+ * producer and consumer wire to different CF queues:
+ * - Producer derivation in `generateWranglerConfig` (`queues.producers[].queue`)
+ * - Consumer entry in `generateWranglerConfig` (`queues.consumers[].queue`)
+ * - Switch case label in the generated `async queue(batch, env, ctx)` handler
+ */
+export function toCFQueueName(input: string): string {
+  if (!input) return ''
+  return input
+    .replace(/([a-z0-9])([A-Z])/g, '$1-$2')
+    .replace(/([A-Z]+)([A-Z][a-z])/g, '$1-$2')
+    .toLowerCase()
+    .replace(/_/g, '-')
+    .replace(/[^a-z0-9-]/g, '-')
+    .replace(/-+/g, '-')
+    .replace(/^-+|-+$/g, '')
 }
 
 const BINDING_PATTERNS: Array<{ pattern: RegExp; type: BindingType }> = [

--- a/packages/provider-cloudflare/src/codegen/generate-script.ts
+++ b/packages/provider-cloudflare/src/codegen/generate-script.ts
@@ -251,7 +251,14 @@ export function generateScript(
   // hoisted to the top of the generated worker.
   let moduleCode = ''
   let fetchHandlerEmission: { params: string; body: string } | null = null
-  const queueHandlerEmissions: Array<{ name: string; params: string; body: string }> = []
+  const queueHandlerEmissions: Array<{
+    /** JS function identifier (used for code-gen comments only). */
+    name: string
+    /** CF-valid queue name (used as the switch case label). */
+    queueName: string
+    params: string
+    body: string
+  }> = []
 
   if (parsed.mode === 'legacy') {
     const { imports, body } = extractImports(parsed.fetchBody)
@@ -271,7 +278,12 @@ export function generateScript(
     for (const qh of parsed.queueHandlers) {
       const { imports, body } = extractImports(qh.body)
       collectedImports.push(...imports)
-      queueHandlerEmissions.push({ name: qh.name, params: qh.params, body })
+      queueHandlerEmissions.push({
+        name: qh.name,
+        queueName: qh.queueName ?? qh.name,
+        params: qh.params,
+        body,
+      })
     }
   }
 
@@ -314,7 +326,7 @@ ${indent(fetchHandlerEmission.body, 4)}
     const cases = queueHandlerEmissions
       .map((qh) => {
         const trailing = endsWithReturn(qh.body) ? '' : '\n        return'
-        return `      case "${qh.name}": {
+        return `      case "${qh.queueName}": {
 ${indent(qh.body, 8)}${trailing}
       }`
       })

--- a/packages/provider-cloudflare/src/codegen/generate-workflow.ts
+++ b/packages/provider-cloudflare/src/codegen/generate-workflow.ts
@@ -196,7 +196,12 @@ export function generateWorkflow(
   // @fetch declaration and a switched queue handler from @queue declarations.
   let moduleCode = ''
   let fetchHandlerEmission: { params: string; body: string } | null = null
-  const queueHandlerEmissions: Array<{ name: string; params: string; body: string }> = []
+  const queueHandlerEmissions: Array<{
+    name: string
+    queueName: string
+    params: string
+    body: string
+  }> = []
 
   if (parsed.mode === 'legacy') {
     const { imports, body } = extractImports(parsed.fetchBody)
@@ -216,7 +221,12 @@ export function generateWorkflow(
     for (const qh of parsed.queueHandlers) {
       const { imports, body } = extractImports(qh.body)
       collectedImports.push(...imports)
-      queueHandlerEmissions.push({ name: qh.name, params: qh.params, body })
+      queueHandlerEmissions.push({
+        name: qh.name,
+        queueName: qh.queueName ?? qh.name,
+        params: qh.params,
+        body,
+      })
     }
   }
 
@@ -239,7 +249,7 @@ ${indent(fetchHandlerEmission.body, 4)}
     const cases = queueHandlerEmissions
       .map((qh) => {
         const trailing = endsWithReturn(qh.body) ? '' : '\n        return'
-        return `      case "${qh.name}": {
+        return `      case "${qh.queueName}": {
 ${indent(qh.body, 8)}${trailing}
       }`
       })

--- a/packages/provider-cloudflare/src/codegen/generate.ts
+++ b/packages/provider-cloudflare/src/codegen/generate.ts
@@ -4,7 +4,7 @@ import { generateWorkflow } from './generate-workflow.js'
 import { generateScript } from './generate-script.js'
 
 export { extractImports, generateNodeCode } from './generate-helpers.js'
-export { deriveQueueName } from './bindings.js'
+export { deriveQueueName, toCFQueueName } from './bindings.js'
 export { DEFAULT_TRIGGER_CODE, generateWorkflow } from './generate-workflow.js'
 export type { GenerateOptions } from './generate-workflow.js'
 export { DEFAULT_SCRIPT_TRIGGER_CODE, generateScript } from './generate-script.js'

--- a/packages/provider-cloudflare/src/codegen/parse-annotations.ts
+++ b/packages/provider-cloudflare/src/codegen/parse-annotations.ts
@@ -1,4 +1,5 @@
 import { cloudflareInlineQueueConfigSchema } from '../config-schema.js'
+import { toCFQueueName } from './bindings.js'
 
 /**
  * Parses trigger code for `@kind function name(params) { body }` annotations
@@ -32,7 +33,18 @@ export interface StrictParseResult {
 }
 
 export interface HandlerDecl {
+  /** The JS function identifier as written by the user. */
   name: string
+  /**
+   * For `@queue` handlers: the CF-valid queue name derived from `name`.
+   * Computed at parse time via `toCFQueueName`. Used as the switch case
+   * label in the generated `async queue(...)` handler and as the `queue`
+   * field in wrangler.json's `queues.consumers[]`. Always lowercase,
+   * alphanumeric + hyphens only — matches what CF accepts.
+   *
+   * Undefined for non-queue handlers (`@fetch`).
+   */
+  queueName?: string
   params: string
   body: string
   line: number
@@ -113,6 +125,7 @@ function buildStrictResult(source: string, annotations: RawAnnotation[]): Strict
       const { config, cleanedBody } = extractConfigBlock(ann.body, ann.line)
       queueHandlers.push({
         name: ann.name,
+        queueName: toCFQueueName(ann.name),
         params: ann.params,
         body: cleanedBody,
         line: ann.line,

--- a/packages/provider-cloudflare/src/index.ts
+++ b/packages/provider-cloudflare/src/index.ts
@@ -11,6 +11,7 @@ export {
   detectBindings,
   detectBindingsFromSource,
   deriveQueueName,
+  toCFQueueName,
   type BindingRequirement,
   type BindingType,
 } from './codegen/bindings.js'

--- a/packages/provider-cloudflare/src/wrangler-config.ts
+++ b/packages/provider-cloudflare/src/wrangler-config.ts
@@ -1,4 +1,4 @@
-import { deriveQueueName, type BindingRequirement } from './codegen/bindings.js'
+import { deriveQueueName, toCFQueueName, type BindingRequirement } from './codegen/bindings.js'
 import type { SubWorkflowBinding } from './codegen/generators/sub-workflow.js'
 
 export const WRANGLER_BASE_CONFIG = {
@@ -166,10 +166,17 @@ export function generateWranglerConfig(config: WranglerWorkflowConfig): string {
           r2Bindings.push({ binding: b.name, bucket_name: b.resourceId ?? b.name.toLowerCase() })
           break
         case 'queue':
-          // Default queue name strips the `QUEUE_` prefix so producer and
-          // consumer (`@queue function NAME`) agree on the same CF queue.
-          // Users can override via the `<NAME>_BINDING_ID` env var convention.
-          queueProducers.push({ binding: b.name, queue: b.resourceId ?? deriveQueueName(b.name) })
+          // CF queue names must be lowercase alphanumeric + hyphens only
+          // (no underscores). We derive the JS-identifier form first
+          // (`QUEUE_FOO_BAR` → `foo_bar`) then normalize to CF naming
+          // (`foo_bar` → `foo-bar`). Same conversion applied to consumer
+          // function names so producer and consumer agree.
+          // The `<NAME>_BINDING_ID` env var override is taken verbatim
+          // (the user is responsible for using a CF-valid name).
+          queueProducers.push({
+            binding: b.name,
+            queue: b.resourceId ?? toCFQueueName(deriveQueueName(b.name)),
+          })
           break
         case 'service':
           serviceBindings.push({ binding: b.name, service: b.resourceId ?? b.name.toLowerCase() })


### PR DESCRIPTION
## Summary

Cloudflare's wrangler validation rejects queue names with anything other than lowercase alphanumeric characters and hyphens — no underscores, no uppercase. Our codegen was emitting names like \`marktplaats_processor\` (derived from \`QUEUE_MARKTPLAATS_PROCESSOR\` binding or \`@queue function marktplaats_processor\`) which CF refuses to deploy.

## Fix

New \`toCFQueueName(input)\` helper that converts any string (snake_case, camelCase, mixed) to a CF-valid name. Applied to both producer derivation (wrangler \`queues.producers[].queue\`) and consumer derivation (wrangler \`queues.consumers[].queue\` + switch case label) so both sides agree on the same final name.

| Input | toCFQueueName output |
|---|---|
| \`marktplaats_processor\` | \`marktplaats-processor\` |
| \`marktplaatsProcessor\` | \`marktplaats-processor\` |
| \`MARKTPLAATS_PROCESSOR\` | \`marktplaats-processor\` |
| \`emails\` | \`emails\` |

\`deriveQueueName\` (which produces a JS identifier for the bindings-panel "+ Consume" snippet) is unchanged. The new normalizer sits on top whenever the name crosses the wire to CF.

Deployment-config \`queueConsumers\` overrides match by EITHER the JS function name or the CF queue name, so users can write either form without breaking the override.

Users still create queues out-of-band (CF dashboard or \`wrangler queues create foo-bar\`) — same model as KV/D1/Hyperdrive.

## Test plan

- [x] All 1336 tests pass (+17 new); lint + type-check + build clean
- [x] 11 new \`toCFQueueName\` tests cover snake/camel/mixed/edge cases + producer-consumer alignment
- [x] Wrangler-config test asserts emitted queue name matches \`/^[a-z0-9-]+$/\`
- [x] Generator tests verify switch case label uses kebab-case (snake_case → kebab, camelCase → kebab)
- [ ] Manual: deploy a workflow with \`@queue function foo_bar(...)\` and \`env.QUEUE_FOO_BAR.send(...)\` — confirm wrangler.json has \`queue: "foo-bar"\` on both producer and consumer entries
- [ ] Manual: create the queue once via \`wrangler queues create foo-bar\` and verify deploy succeeds