### PR TITLE
feat(canvas): copy/paste, duplicate, and right-click menu

### DIFF
--- a/apps/web/src/components/canvas/canvas-context-menu.tsx
+++ b/apps/web/src/components/canvas/canvas-context-menu.tsx
@@ -1,0 +1,100 @@
+import { useEffect, useRef, type ComponentType } from 'react'
+import { Copy, Files, Trash2, ClipboardPaste } from 'lucide-react'
+
+export type ContextMenuAction = 'duplicate' | 'copy' | 'delete' | 'paste'
+
+interface CanvasContextMenuProps {
+  x: number
+  y: number
+  type: 'node' | 'pane'
+  onAction: (action: ContextMenuAction) => void
+  onClose: () => void
+}
+
+const isMac =
+  typeof navigator !== 'undefined' && /mac|iphone|ipad|ipod/i.test(navigator.platform || '')
+const mod = isMac ? '⌘' : 'Ctrl+'
+
+export function CanvasContextMenu({ x, y, type, onAction, onClose }: CanvasContextMenuProps) {
+  const ref = useRef<HTMLDivElement>(null)
+
+  useEffect(() => {
+    function handlePointerDown(e: MouseEvent) {
+      if (ref.current && !ref.current.contains(e.target as Node)) onClose()
+    }
+    function handleKeyDown(e: KeyboardEvent) {
+      if (e.key === 'Escape') onClose()
+    }
+    document.addEventListener('mousedown', handlePointerDown)
+    document.addEventListener('keydown', handleKeyDown)
+    return () => {
+      document.removeEventListener('mousedown', handlePointerDown)
+      document.removeEventListener('keydown', handleKeyDown)
+    }
+  }, [onClose])
+
+  return (
+    <div
+      ref={ref}
+      style={{ left: x, top: y }}
+      className="fixed z-50 min-w-[180px] rounded-md border border-border bg-card py-1 shadow-lg"
+      onContextMenu={(e) => e.preventDefault()}
+    >
+      {type === 'node' ? (
+        <>
+          <MenuItem
+            icon={Files}
+            label="Duplicate"
+            shortcut={`${mod}D`}
+            onClick={() => onAction('duplicate')}
+          />
+          <MenuItem
+            icon={Copy}
+            label="Copy"
+            shortcut={`${mod}C`}
+            onClick={() => onAction('copy')}
+          />
+          <div className="my-1 h-px bg-border" />
+          <MenuItem
+            icon={Trash2}
+            label="Delete"
+            shortcut="⌫"
+            destructive
+            onClick={() => onAction('delete')}
+          />
+        </>
+      ) : (
+        <MenuItem
+          icon={ClipboardPaste}
+          label="Paste"
+          shortcut={`${mod}V`}
+          onClick={() => onAction('paste')}
+        />
+      )}
+    </div>
+  )
+}
+
+interface MenuItemProps {
+  icon: ComponentType<{ className?: string }>
+  label: string
+  shortcut?: string
+  destructive?: boolean
+  onClick: () => void
+}
+
+function MenuItem({ icon: Icon, label, shortcut, destructive, onClick }: MenuItemProps) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      className={`flex w-full items-center gap-2 px-3 py-1.5 text-xs transition-colors hover:bg-muted/60 ${
+        destructive ? 'text-destructive' : 'text-foreground'
+      }`}
+    >
+      <Icon className="h-3.5 w-3.5" />
+      <span className="flex-1 text-left">{label}</span>
+      {shortcut && <span className="text-[10px] text-muted-foreground">{shortcut}</span>}
+    </button>
+  )
+}

--- a/apps/web/src/components/canvas/workflow-canvas.tsx
+++ b/apps/web/src/components/canvas/workflow-canvas.tsx
@@ -18,6 +18,7 @@ import { useNodeRegistry } from '../../contexts/node-registry-context'
 import { nodeTypes } from './nodes'
 import { LabeledEdge } from './labeled-edge'
 import { buildContainerEdgeColors } from '../../lib/container-edge-colors'
+import { CanvasContextMenu, type ContextMenuAction } from './canvas-context-menu'
 
 const edgeTypes = { smoothstep: LabeledEdge }
 
@@ -39,10 +40,16 @@ export function WorkflowCanvas() {
     duplicateNodes,
     copyNodesToClipboard,
     pasteNodesFromClipboard,
+    removeNode,
     readOnly,
   } = useWorkflowStore()
   const { registry } = useNodeRegistry()
   const [hoveredEdgeId, setHoveredEdgeId] = useState<string | null>(null)
+  const [contextMenu, setContextMenu] = useState<
+    | { type: 'node'; x: number; y: number; nodeId: string }
+    | { type: 'pane'; x: number; y: number; flowPosition: { x: number; y: number } }
+    | null
+  >(null)
 
   const validatedSelectNode = useCallback(
     (nodeId: string | null) => {
@@ -111,6 +118,65 @@ export function WorkflowCanvas() {
     const single = useWorkflowStore.getState().selectedNodeId
     return single ? [single] : []
   }, [])
+
+  const onNodeContextMenu = useCallback((event: React.MouseEvent, node: FlowNode) => {
+    event.preventDefault()
+    setContextMenu({ type: 'node', x: event.clientX, y: event.clientY, nodeId: node.id })
+  }, [])
+
+  const onPaneContextMenu = useCallback((event: React.MouseEvent | MouseEvent) => {
+    event.preventDefault()
+    if (!reactFlowInstance.current) return
+    const flowPosition = reactFlowInstance.current.screenToFlowPosition({
+      x: event.clientX,
+      y: event.clientY,
+    })
+    setContextMenu({ type: 'pane', x: event.clientX, y: event.clientY, flowPosition })
+  }, [])
+
+  const handleContextMenuAction = useCallback(
+    (action: ContextMenuAction) => {
+      if (!contextMenu) return
+      if (contextMenu.type === 'node') {
+        const selected = useWorkflowStore
+          .getState()
+          .nodes.filter((n) => n.selected)
+          .map((n) => n.id)
+        const ids = selected.includes(contextMenu.nodeId) ? selected : [contextMenu.nodeId]
+        if (action === 'duplicate') {
+          if (!readOnly) {
+            const newIds = duplicateNodes(ids)
+            if (newIds.length > 1) toast.success(`Duplicated ${newIds.length} nodes`)
+          }
+        } else if (action === 'copy') {
+          void copyNodesToClipboard(ids).then((ok) => {
+            if (ok) toast.success(ids.length === 1 ? 'Node copied' : `${ids.length} nodes copied`)
+          })
+        } else if (action === 'delete') {
+          if (!readOnly) {
+            ids.forEach((id) => removeNode(id))
+          }
+        }
+      } else if (action === 'paste') {
+        if (!readOnly) {
+          void pasteNodesFromClipboard(contextMenu.flowPosition).then((newIds) => {
+            if (newIds.length > 0) {
+              toast.success(newIds.length === 1 ? 'Node pasted' : `${newIds.length} nodes pasted`)
+            }
+          })
+        }
+      }
+      setContextMenu(null)
+    },
+    [
+      contextMenu,
+      duplicateNodes,
+      copyNodesToClipboard,
+      pasteNodesFromClipboard,
+      removeNode,
+      readOnly,
+    ],
+  )
 
   const getViewportCenter = useCallback(() => {
     const instance = reactFlowInstance.current
@@ -230,6 +296,8 @@ export function WorkflowCanvas() {
         onNodeClick={(_event, node) => validatedSelectNode(node.id)}
         onEdgeClick={(_event, edge) => selectEdge(edge.id)}
         onPaneClick={() => validatedSelectNode(null)}
+        onNodeContextMenu={onNodeContextMenu}
+        onPaneContextMenu={onPaneContextMenu}
         nodeTypes={nodeTypes as NodeTypes}
         edgeTypes={edgeTypes}
         fitView
@@ -261,6 +329,15 @@ export function WorkflowCanvas() {
           zoomable
         />
       </ReactFlow>
+      {contextMenu && (
+        <CanvasContextMenu
+          x={contextMenu.x}
+          y={contextMenu.y}
+          type={contextMenu.type}
+          onAction={handleContextMenuAction}
+          onClose={() => setContextMenu(null)}
+        />
+      )}
     </div>
   )
 }

--- a/apps/web/src/components/canvas/workflow-canvas.tsx
+++ b/apps/web/src/components/canvas/workflow-canvas.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useRef, useState, useMemo } from 'react'
+import { useCallback, useEffect, useRef, useState, useMemo } from 'react'
 import {
   ReactFlow,
   Background,
@@ -23,6 +23,7 @@ const edgeTypes = { smoothstep: LabeledEdge }
 
 export function WorkflowCanvas() {
   const reactFlowInstance = useRef<ReactFlowInstance<FlowNode> | null>(null)
+  const containerRef = useRef<HTMLDivElement | null>(null)
   const {
     nodes,
     edges,
@@ -35,6 +36,9 @@ export function WorkflowCanvas() {
     selectEdge,
     selectedNodeId,
     selectedEdgeId,
+    duplicateNodes,
+    copyNodesToClipboard,
+    pasteNodesFromClipboard,
     readOnly,
   } = useWorkflowStore()
   const { registry } = useNodeRegistry()
@@ -98,6 +102,77 @@ export function WorkflowCanvas() {
     setHoveredEdgeId(null)
   }, [])
 
+  const getActiveSelection = useCallback(() => {
+    const current = useWorkflowStore
+      .getState()
+      .nodes.filter((n) => n.selected)
+      .map((n) => n.id)
+    if (current.length > 0) return current
+    const single = useWorkflowStore.getState().selectedNodeId
+    return single ? [single] : []
+  }, [])
+
+  const getViewportCenter = useCallback(() => {
+    const instance = reactFlowInstance.current
+    const el = containerRef.current
+    if (!instance || !el) return undefined
+    const rect = el.getBoundingClientRect()
+    return instance.screenToFlowPosition({
+      x: rect.left + rect.width / 2,
+      y: rect.top + rect.height / 2,
+    })
+  }, [])
+
+  useEffect(() => {
+    function isTypingTarget(target: EventTarget | null): boolean {
+      const el = target as HTMLElement | null
+      if (!el) return false
+      const tag = el.tagName
+      return tag === 'INPUT' || tag === 'TEXTAREA' || el.isContentEditable
+    }
+
+    function handleKeyDown(e: KeyboardEvent) {
+      if (!(e.metaKey || e.ctrlKey) || e.altKey) return
+      if (isTypingTarget(e.target)) return
+      const key = e.key.toLowerCase()
+      if (key === 'd') {
+        const ids = getActiveSelection()
+        if (ids.length === 0) return
+        e.preventDefault()
+        if (readOnly) return
+        const newIds = duplicateNodes(ids)
+        if (newIds.length > 1) {
+          toast.success(`Duplicated ${newIds.length} nodes`)
+        }
+      } else if (key === 'c') {
+        const ids = getActiveSelection()
+        if (ids.length === 0) return
+        e.preventDefault()
+        void copyNodesToClipboard(ids).then((ok) => {
+          if (ok) toast.success(ids.length === 1 ? 'Node copied' : `${ids.length} nodes copied`)
+        })
+      } else if (key === 'v') {
+        if (readOnly) return
+        e.preventDefault()
+        const center = getViewportCenter()
+        void pasteNodesFromClipboard(center).then((newIds) => {
+          if (newIds.length > 0) {
+            toast.success(newIds.length === 1 ? 'Node pasted' : `${newIds.length} nodes pasted`)
+          }
+        })
+      }
+    }
+    window.addEventListener('keydown', handleKeyDown)
+    return () => window.removeEventListener('keydown', handleKeyDown)
+  }, [
+    duplicateNodes,
+    copyNodesToClipboard,
+    pasteNodesFromClipboard,
+    readOnly,
+    getActiveSelection,
+    getViewportCenter,
+  ])
+
   // Container edge colors only depend on graph topology (node types + edge connections).
   // Position drags change node references but not edge references — use edges array
   // identity as the primary cache key to avoid any work on drag frames.
@@ -137,53 +212,55 @@ export function WorkflowCanvas() {
   }, [edges, hoveredEdgeId, selectedEdgeId, containerEdgeColors])
 
   return (
-    <ReactFlow
-      nodes={nodes}
-      edges={styledEdges}
-      onNodesChange={onNodesChange}
-      onEdgesChange={onEdgesChange}
-      onConnect={onConnect}
-      nodesDraggable={!readOnly}
-      nodesConnectable={!readOnly}
-      onInit={(instance) => {
-        reactFlowInstance.current = instance
-      }}
-      onDragOver={onDragOver}
-      onDrop={onDrop}
-      onDragLeave={onDragLeave}
-      onNodeClick={(_event, node) => validatedSelectNode(node.id)}
-      onEdgeClick={(_event, edge) => selectEdge(edge.id)}
-      onPaneClick={() => validatedSelectNode(null)}
-      nodeTypes={nodeTypes as NodeTypes}
-      edgeTypes={edgeTypes}
-      fitView
-      snapToGrid
-      snapGrid={[20, 20]}
-      defaultEdgeOptions={{
-        type: 'smoothstep',
-        style: { stroke: 'var(--muted-foreground)', strokeWidth: 0.5 },
-      }}
-      proOptions={{ hideAttribution: true }}
-      className="!bg-background"
-    >
-      <Background
-        variant={BackgroundVariant.Dots}
-        gap={20}
-        size={1}
-        color="var(--muted-foreground)"
-        style={{ opacity: 0.3 }}
-      />
-      <Controls
-        showInteractive={false}
-        className="!rounded-lg !border !border-border !bg-card !shadow-lg [&_button]:!border-border [&_button]:!bg-transparent [&_button]:!text-muted-foreground [&_button:hover]:!bg-muted/60 [&_button:hover]:!text-foreground/80"
-      />
-      <MiniMap
-        className="!rounded-lg !border !border-border !bg-card"
-        nodeColor="var(--muted-foreground)"
-        maskColor="var(--background)"
-        pannable
-        zoomable
-      />
-    </ReactFlow>
+    <div ref={containerRef} className="h-full w-full">
+      <ReactFlow
+        nodes={nodes}
+        edges={styledEdges}
+        onNodesChange={onNodesChange}
+        onEdgesChange={onEdgesChange}
+        onConnect={onConnect}
+        nodesDraggable={!readOnly}
+        nodesConnectable={!readOnly}
+        onInit={(instance) => {
+          reactFlowInstance.current = instance
+        }}
+        onDragOver={onDragOver}
+        onDrop={onDrop}
+        onDragLeave={onDragLeave}
+        onNodeClick={(_event, node) => validatedSelectNode(node.id)}
+        onEdgeClick={(_event, edge) => selectEdge(edge.id)}
+        onPaneClick={() => validatedSelectNode(null)}
+        nodeTypes={nodeTypes as NodeTypes}
+        edgeTypes={edgeTypes}
+        fitView
+        snapToGrid
+        snapGrid={[20, 20]}
+        defaultEdgeOptions={{
+          type: 'smoothstep',
+          style: { stroke: 'var(--muted-foreground)', strokeWidth: 0.5 },
+        }}
+        proOptions={{ hideAttribution: true }}
+        className="!bg-background"
+      >
+        <Background
+          variant={BackgroundVariant.Dots}
+          gap={20}
+          size={1}
+          color="var(--muted-foreground)"
+          style={{ opacity: 0.3 }}
+        />
+        <Controls
+          showInteractive={false}
+          className="!rounded-lg !border !border-border !bg-card !shadow-lg [&_button]:!border-border [&_button]:!bg-transparent [&_button]:!text-muted-foreground [&_button:hover]:!bg-muted/60 [&_button:hover]:!text-foreground/80"
+        />
+        <MiniMap
+          className="!rounded-lg !border !border-border !bg-card"
+          nodeColor="var(--muted-foreground)"
+          maskColor="var(--background)"
+          pannable
+          zoomable
+        />
+      </ReactFlow>
+    </div>
   )
 }

--- a/apps/web/src/stores/workflow-store.ts
+++ b/apps/web/src/stores/workflow-store.ts
@@ -38,6 +38,69 @@ export function toFlowType(irType: string): string {
   return BUILTIN_FLOW_TYPES.has(irType) ? irType : 'custom'
 }
 
+const CLIPBOARD_FORMAT = 'awaitstep/nodes-v1'
+
+interface ClipboardEdge {
+  source: string
+  target: string
+  label?: string
+}
+
+interface ClipboardPayload {
+  __awaitstep: typeof CLIPBOARD_FORMAT
+  nodes: WorkflowNode[]
+  edges: ClipboardEdge[]
+}
+
+function isClipboardPayload(value: unknown): value is ClipboardPayload {
+  if (typeof value !== 'object' || value === null) return false
+  const obj = value as Record<string, unknown>
+  return (
+    obj.__awaitstep === CLIPBOARD_FORMAT && Array.isArray(obj.nodes) && Array.isArray(obj.edges)
+  )
+}
+
+function buildClipboardPayload(
+  nodes: FlowNode[],
+  edges: Edge[],
+  nodeIds: string[],
+): ClipboardPayload | null {
+  const idSet = new Set(nodeIds)
+  const sourceNodes = nodes.filter((n) => idSet.has(n.id)).map((n) => n.data.irNode)
+  if (sourceNodes.length === 0) return null
+  const sourceEdges = edges
+    .filter((e) => idSet.has(e.source) && idSet.has(e.target))
+    .map<ClipboardEdge>((e) => ({
+      source: e.source,
+      target: e.target,
+      ...(typeof e.label === 'string' ? { label: e.label } : {}),
+    }))
+  return { __awaitstep: CLIPBOARD_FORMAT, nodes: sourceNodes, edges: sourceEdges }
+}
+
+function instantiateClones(
+  payload: ClipboardPayload,
+  offset: { x: number; y: number },
+): { nodes: FlowNode[]; edges: Edge[] } {
+  const idMap = new Map<string, string>()
+  const newNodes: FlowNode[] = payload.nodes.map((src) => {
+    const newId = nanoid()
+    idMap.set(src.id, newId)
+    const position = { x: src.position.x + offset.x, y: src.position.y + offset.y }
+    const irNode: WorkflowNode = { ...structuredClone(src), id: newId, position }
+    return { id: newId, type: toFlowType(irNode.type), position, data: { irNode } }
+  })
+  const newEdges: Edge[] = payload.edges
+    .filter((e) => idMap.has(e.source) && idMap.has(e.target))
+    .map((e) => ({
+      id: nanoid(),
+      source: idMap.get(e.source)!,
+      target: idMap.get(e.target)!,
+      ...(e.label ? { label: e.label } : {}),
+    }))
+  return { nodes: newNodes, edges: newEdges }
+}
+
 export interface WorkflowNodeData extends Record<string, unknown> {
   irNode: WorkflowNode
 }
@@ -115,6 +178,9 @@ interface WorkflowState {
   removeNode: (nodeId: string) => void
   selectNode: (nodeId: string | null) => void
   selectEdge: (edgeId: string | null) => void
+  duplicateNodes: (nodeIds: string[]) => string[]
+  copyNodesToClipboard: (nodeIds: string[]) => Promise<boolean>
+  pasteNodesFromClipboard: (centerPosition?: { x: number; y: number }) => Promise<string[]>
 
   setKind: (kind: 'workflow' | 'script') => void
   setMetadata: (metadata: Partial<WorkflowMetadata>) => void
@@ -390,6 +456,82 @@ export const useWorkflowStore = create<WorkflowState>((set, get) => ({
 
   selectEdge: (edgeId) => {
     set({ selectedEdgeId: edgeId, selectedNodeId: null })
+  },
+
+  duplicateNodes: (nodeIds) => {
+    if (get().readOnly || nodeIds.length === 0) return []
+    const { nodes, edges } = get()
+    const payload = buildClipboardPayload(nodes, edges, nodeIds)
+    if (!payload) return []
+    const cloned = instantiateClones(payload, { x: 40, y: 40 })
+    const newIds = cloned.nodes.map((n) => n.id)
+    set({
+      nodes: [
+        ...nodes.map((n) => (n.selected ? { ...n, selected: false } : n)),
+        ...cloned.nodes.map((n) => ({ ...n, selected: true })),
+      ],
+      edges: [...edges, ...cloned.edges],
+      selectedNodeId: newIds[0] ?? null,
+      selectedEdgeId: null,
+      isDirty: true,
+    })
+    return newIds
+  },
+
+  copyNodesToClipboard: async (nodeIds) => {
+    if (nodeIds.length === 0) return false
+    const { nodes, edges } = get()
+    const payload = buildClipboardPayload(nodes, edges, nodeIds)
+    if (!payload) return false
+    try {
+      await navigator.clipboard.writeText(JSON.stringify(payload))
+      return true
+    } catch {
+      return false
+    }
+  },
+
+  pasteNodesFromClipboard: async (centerPosition) => {
+    if (get().readOnly) return []
+    let raw: string
+    try {
+      raw = await navigator.clipboard.readText()
+    } catch {
+      return []
+    }
+    if (!raw) return []
+    let parsed: unknown
+    try {
+      parsed = JSON.parse(raw)
+    } catch {
+      return []
+    }
+    if (!isClipboardPayload(parsed)) return []
+
+    let offset: { x: number; y: number }
+    if (centerPosition && parsed.nodes.length > 0) {
+      const cx = parsed.nodes.reduce((s, n) => s + n.position.x, 0) / parsed.nodes.length
+      const cy = parsed.nodes.reduce((s, n) => s + n.position.y, 0) / parsed.nodes.length
+      offset = { x: centerPosition.x - cx, y: centerPosition.y - cy }
+    } else {
+      offset = { x: 40, y: 40 }
+    }
+
+    const cloned = instantiateClones(parsed, offset)
+    if (cloned.nodes.length === 0) return []
+    const newIds = cloned.nodes.map((n) => n.id)
+    const { nodes, edges } = get()
+    set({
+      nodes: [
+        ...nodes.map((n) => (n.selected ? { ...n, selected: false } : n)),
+        ...cloned.nodes.map((n) => ({ ...n, selected: true })),
+      ],
+      edges: [...edges, ...cloned.edges],
+      selectedNodeId: newIds[0] ?? null,
+      selectedEdgeId: null,
+      isDirty: true,
+    })
+    return newIds
   },
 
   setKind: (kind) => {


### PR DESCRIPTION
## Summary
End-to-end node clipboard support on the canvas, including multi-node selection, system-clipboard copy/paste across tabs, and a right-click context menu.

**Store** (`workflow-store.ts`)
- `duplicateNodes(ids)` — clones selected nodes (and their internal edges) with fresh IDs at +40/+40 offset; selects the new set.
- `copyNodesToClipboard(ids)` — writes a versioned JSON payload (`awaitstep/nodes-v1`) to `navigator.clipboard`.
- `pasteNodesFromClipboard(centerPosition?)` — reads + validates the payload and instantiates clones; recenters at `centerPosition` if provided, otherwise +40/+40.
- Edges crossing the selection boundary are dropped on copy/duplicate.

**Keyboard** (`workflow-canvas.tsx`)
- `Cmd/Ctrl+D` duplicate, `Cmd/Ctrl+C` copy, `Cmd/Ctrl+V` paste at viewport center.
- All shortcuts skip when an INPUT/TEXTAREA/contentEditable target has focus and short-circuit on `readOnly`.
- Selection set comes from ReactFlow's per-node `selected` flag, so shift-click and box-select multi-selections work without further wiring.

**Right-click menu** (new `canvas-context-menu.tsx`)
- Node menu: Duplicate, Copy, Delete.
- Pane menu: Paste at the cursor's flow-coordinate position.
- If the right-clicked node is part of a multi-selection the action applies to the whole set; otherwise just the clicked node.
- Closes on outside click and Escape; shortcut hints render `⌘` on macOS, `Ctrl+` elsewhere.

## Test plan
- [ ] Single node: Cmd+D duplicates with +40/+40 offset; new node becomes the editor selection.
- [ ] Shift-click two nodes connected by an edge → Cmd+D → both nodes and the connecting edge are cloned.
- [ ] Cmd+C in tab A, Cmd+V in tab B → nodes appear at the new tab's viewport center.
- [ ] Cmd+V with no clipboard or unrelated clipboard text → no-op (no toast).
- [ ] Right-click empty node → menu shows Duplicate / Copy / Delete; each works.
- [ ] Right-click selection of 3 nodes → Delete removes all 3.
- [ ] Right-click empty pane → Paste lands the cluster centered on the cursor.
- [ ] Esc and click-outside both close the menu.
- [ ] Cmd+D inside the editor textarea does NOT duplicate (typing guard).
- [ ] On a `readOnly` workflow, all three shortcuts are no-ops.