### PR TITLE
fix(codegen): container then-continuation + inline step toggle

### DIFF
--- a/apps/web/src/components/canvas/node-config-panel.tsx
+++ b/apps/web/src/components/canvas/node-config-panel.tsx
@@ -16,7 +16,24 @@ import { useNodeRegistry } from '../../contexts/node-registry-context'
 import { customAlphabet } from 'nanoid'
 
 const nanoid = customAlphabet('abcdefghijklmnopqrstuvwxyz0123456789_', 12)
-import type { WorkflowNode, BranchCondition } from '@awaitstep/ir'
+import type { WorkflowNode, BranchCondition, ConfigField } from '@awaitstep/ir'
+
+const STEP_DURABLE_FIELDS = new Set(['retryLimit', 'retryDelay', 'backoff', 'timeout'])
+
+function filterStepConfigSchema(
+  schema: Record<string, ConfigField>,
+  isScript: boolean,
+  isInline: boolean,
+): Record<string, ConfigField> {
+  if (!isScript && !isInline) return schema
+  const filtered: Record<string, ConfigField> = {}
+  for (const [key, field] of Object.entries(schema)) {
+    if (isScript && key === 'inline') continue
+    if ((isScript || isInline) && STEP_DURABLE_FIELDS.has(key)) continue
+    filtered[key] = field
+  }
+  return filtered
+}
 
 const NESTED_STEP_PATTERN = /step\.(do|sleep|sleepUntil|waitForEvent)\s*\(/
 
@@ -76,8 +93,8 @@ export function validateNode(node: WorkflowNode): string[] {
 }
 
 export function NodeConfigPanel() {
-  const { selectedNodeId, nodes } = useWorkflowStore(
-    useShallow((s) => ({ selectedNodeId: s.selectedNodeId, nodes: s.nodes })),
+  const { selectedNodeId, nodes, kind } = useWorkflowStore(
+    useShallow((s) => ({ selectedNodeId: s.selectedNodeId, nodes: s.nodes, kind: s.kind })),
   )
   const { updateNodeData, removeNode, selectNode } = useWorkflowStore()
   const { registry } = useNodeRegistry()
@@ -197,7 +214,15 @@ export function NodeConfigPanel() {
             </>
           ) : definition ? (
             <DynamicFields
-              configSchema={definition.configSchema}
+              configSchema={
+                irNode.type === 'step'
+                  ? filterStepConfigSchema(
+                      definition.configSchema,
+                      kind === 'script',
+                      Boolean(irNode.data.inline),
+                    )
+                  : definition.configSchema
+              }
               data={irNode.data}
               onChange={updateData}
             />

--- a/apps/web/src/components/dashboard/import-workflow-dialog.tsx
+++ b/apps/web/src/components/dashboard/import-workflow-dialog.tsx
@@ -1,9 +1,9 @@
-import { useState, useRef } from 'react'
+import { useState, useRef, useMemo } from 'react'
 import { useNavigate } from '@tanstack/react-router'
 import { useMutation, useQueryClient } from '@tanstack/react-query'
 import { Upload, FileText, AlertCircle, Loader2 } from 'lucide-react'
 import * as Dialog from '@radix-ui/react-dialog'
-import { validateArtifact } from '@awaitstep/ir'
+import { validateArtifact, SCRIPT_INCOMPATIBLE_NODE_TYPES } from '@awaitstep/ir'
 import type { ArtifactIR } from '@awaitstep/ir'
 import { Button } from '../ui/button'
 import { CodeEditor } from '../ui/code-editor'
@@ -11,6 +11,31 @@ import { api } from '../../lib/api-client'
 import { toast } from 'sonner'
 
 type InputMode = 'paste' | 'file'
+type IRKind = 'workflow' | 'script'
+
+function detectedKind(ir: ArtifactIR): IRKind {
+  return ir.kind === 'script' ? 'script' : 'workflow'
+}
+
+function transformIR(ir: ArtifactIR, kind: IRKind): ArtifactIR {
+  if (kind === 'script') {
+    const trigger =
+      ir.trigger && ir.trigger.type === 'http' ? ir.trigger : ({ type: 'http' } as const)
+    return { ...ir, kind: 'script', trigger }
+  }
+  const { trigger, ...rest } = ir
+  return trigger ? { ...rest, kind: 'workflow', trigger } : { ...rest, kind: 'workflow' }
+}
+
+function incompatibleNodeTypes(ir: ArtifactIR): string[] {
+  const counts = new Map<string, number>()
+  for (const node of ir.nodes) {
+    if (SCRIPT_INCOMPATIBLE_NODE_TYPES.has(node.type)) {
+      counts.set(node.type, (counts.get(node.type) ?? 0) + 1)
+    }
+  }
+  return Array.from(counts.entries()).map(([type, count]) => `${count}× ${type}`)
+}
 
 function parseAndValidate(
   raw: string,
@@ -42,6 +67,7 @@ export function ImportWorkflowDialog({ onClose }: { onClose: () => void }) {
   const [fileName, setFileName] = useState<string | null>(null)
   const [name, setName] = useState('')
   const [validIR, setValidIR] = useState<ArtifactIR | null>(null)
+  const [selectedKind, setSelectedKind] = useState<IRKind>('workflow')
   const [errors, setErrors] = useState<string[]>([])
   const [isDragOver, setIsDragOver] = useState(false)
   const fileInputRef = useRef<HTMLInputElement>(null)
@@ -62,6 +88,7 @@ export function ImportWorkflowDialog({ onClose }: { onClose: () => void }) {
       setValidIR(result.ir)
       setErrors([])
       setName(result.ir.metadata.name)
+      setSelectedKind(detectedKind(result.ir))
     }
   }
 
@@ -71,6 +98,7 @@ export function ImportWorkflowDialog({ onClose }: { onClose: () => void }) {
     setValidIR(null)
     setErrors([])
     setName('')
+    setSelectedKind('workflow')
   }
 
   function switchMode(next: InputMode) {
@@ -115,19 +143,26 @@ export function ImportWorkflowDialog({ onClose }: { onClose: () => void }) {
     setIsDragOver(true)
   }
 
+  const incompatible = useMemo(
+    () => (validIR && selectedKind === 'script' ? incompatibleNodeTypes(validIR) : []),
+    [validIR, selectedKind],
+  )
+  const kindChangeBlocked = incompatible.length > 0
+
   const importMutation = useMutation({
     mutationFn: async () => {
       if (!validIR) throw new Error('No valid IR')
+      const transformed = transformIR(validIR, selectedKind)
       const workflow = await api.createWorkflow({
-        name: name.trim() || validIR.metadata.name,
-        description: validIR.metadata.description,
-        kind: validIR.kind,
+        name: name.trim() || transformed.metadata.name,
+        description: transformed.metadata.description,
+        kind: transformed.kind,
       })
-      await api.createVersion(workflow.id, { ir: validIR })
+      await api.createVersion(workflow.id, { ir: transformed })
       return workflow
     },
     onSuccess: (workflow) => {
-      const isScript = validIR?.kind === 'script'
+      const isScript = selectedKind === 'script'
       queryClient.invalidateQueries({ queryKey: ['workflows'] })
       navigate({
         to: '/workflows/$workflowId/canvas',
@@ -143,7 +178,7 @@ export function ImportWorkflowDialog({ onClose }: { onClose: () => void }) {
   })
 
   const hasInput = jsonText.trim().length > 0
-  const canImport = validIR !== null && !importMutation.isPending
+  const canImport = validIR !== null && !kindChangeBlocked && !importMutation.isPending
 
   return (
     <Dialog.Root open onOpenChange={(v) => !v && onClose()}>
@@ -159,9 +194,8 @@ export function ImportWorkflowDialog({ onClose }: { onClose: () => void }) {
             Import Workflow or Function
           </Dialog.Title>
           <p className="mt-1 text-xs text-muted-foreground">
-            Paste an IR JSON document or upload an exported <code>.ir.json</code> file. The kind (
-            <code>workflow</code> or <code>script</code>) is read from the IR's <code>kind</code>{' '}
-            field; absent <code>kind</code> imports as a workflow.
+            Paste an IR JSON document or upload an exported <code>.ir.json</code> file. The kind is
+            detected from the IR but can be overridden before import.
           </p>
 
           {/* Mode tabs */}
@@ -263,30 +297,66 @@ export function ImportWorkflowDialog({ onClose }: { onClose: () => void }) {
             </div>
           )}
 
-          {/* Name + detected kind (shown when IR is valid) */}
+          {/* Name + kind selector (shown when IR is valid) */}
           {validIR && (
-            <div className="mt-3">
-              <label className="text-xs font-medium text-foreground/60">
-                {validIR.kind === 'script' ? 'Function name' : 'Workflow name'}
-              </label>
-              <input
-                type="text"
-                value={name}
-                onChange={(e) => setName(e.target.value)}
-                className="mt-1 w-full rounded-md border border-border bg-muted/30 px-3 py-2 text-sm text-foreground outline-none focus:border-primary/40"
-              />
-              <p className="mt-1.5 flex items-center gap-2 text-xs text-muted-foreground">
-                <span
-                  className={`rounded px-1.5 py-0.5 text-[10px] font-medium uppercase tracking-wide ${
-                    validIR.kind === 'script'
-                      ? 'bg-violet-500/15 text-violet-600 dark:text-violet-300'
-                      : 'bg-emerald-500/15 text-emerald-600 dark:text-emerald-300'
-                  }`}
-                >
-                  {validIR.kind === 'script' ? 'Function' : 'Workflow'}
-                </span>
-                {validIR.nodes.length} nodes, {validIR.edges.length} edges
-              </p>
+            <div className="mt-3 space-y-3">
+              <div>
+                <label className="text-xs font-medium text-foreground/60">
+                  {selectedKind === 'script' ? 'Function name' : 'Workflow name'}
+                </label>
+                <input
+                  type="text"
+                  value={name}
+                  onChange={(e) => setName(e.target.value)}
+                  className="mt-1 w-full rounded-md border border-border bg-muted/30 px-3 py-2 text-sm text-foreground outline-none focus:border-primary/40"
+                />
+              </div>
+
+              <div>
+                <label className="text-xs font-medium text-foreground/60">Import as</label>
+                <div className="mt-1 flex gap-1 rounded-md border border-border bg-muted/40 p-0.5">
+                  <button
+                    type="button"
+                    onClick={() => setSelectedKind('workflow')}
+                    className={`flex-1 rounded px-3 py-1.5 text-xs font-medium transition-colors ${
+                      selectedKind === 'workflow'
+                        ? 'bg-card text-foreground shadow-sm'
+                        : 'text-muted-foreground hover:text-foreground/60'
+                    }`}
+                  >
+                    Workflow
+                  </button>
+                  <button
+                    type="button"
+                    onClick={() => setSelectedKind('script')}
+                    className={`flex-1 rounded px-3 py-1.5 text-xs font-medium transition-colors ${
+                      selectedKind === 'script'
+                        ? 'bg-card text-foreground shadow-sm'
+                        : 'text-muted-foreground hover:text-foreground/60'
+                    }`}
+                  >
+                    Function
+                  </button>
+                </div>
+                <p className="mt-1.5 text-xs text-muted-foreground">
+                  Detected: {detectedKind(validIR)}. {validIR.nodes.length} nodes,{' '}
+                  {validIR.edges.length} edges.
+                </p>
+              </div>
+
+              {kindChangeBlocked && (
+                <div className="rounded-md border border-destructive/30 bg-destructive/5 p-3">
+                  <div className="flex items-start gap-2">
+                    <AlertCircle className="mt-0.5 h-3.5 w-3.5 shrink-0 text-destructive" />
+                    <div className="text-xs text-destructive">
+                      <p className="font-medium">Cannot import as Function.</p>
+                      <p className="mt-0.5">
+                        Contains nodes not supported in scripts: {incompatible.join(', ')}.
+                      </p>
+                    </div>
+                  </div>
+                </div>
+              )}
             </div>
           )}
 

--- a/packages/ir/src/bundled-nodes/step.ts
+++ b/packages/ir/src/bundled-nodes/step.ts
@@ -16,6 +16,13 @@ export const stepDefinition: NodeDefinition = {
       description:
         'TypeScript code to execute. ctx.attempt is the current retry (1-indexed). Return value must be serializable.',
     },
+    inline: {
+      type: 'boolean',
+      label: 'Inline (no step.do)',
+      default: false,
+      description:
+        'Emit this code directly in the workflow body instead of wrapping it in step.do. Loses durability and retries — use for pure transforms or quick checks.',
+    },
     retryLimit: {
       type: 'number',
       label: 'Retry Limit',

--- a/packages/provider-cloudflare/src/__tests__/codegen/generate.test.ts
+++ b/packages/provider-cloudflare/src/__tests__/codegen/generate.test.ts
@@ -127,6 +127,83 @@ describe('generateWorkflow', () => {
     expect(code).not.toContain('{{fetch_data.userId}}')
     expect(code).toContain('Fetch_Data.userId')
   })
+
+  it('keeps a parallel `then` continuation inside its parent loop body', () => {
+    // Regression: loop body containing a parallel whose `then` edge points to
+    // a follow-up step. The continuation must be emitted INSIDE the loop body
+    // (so it runs once per iteration after the parallel resolves), not at
+    // the top level of `run()` after the loop ends.
+    const ir: WorkflowIR = {
+      metadata: { name: 'NestedLoop', version: 1, createdAt: '', updatedAt: '' },
+      entryNodeId: 'loop',
+      nodes: [
+        {
+          id: 'loop',
+          type: 'loop',
+          name: 'iterate',
+          position: { x: 0, y: 0 },
+          version: '1.0.0',
+          provider: 'cloudflare',
+          data: { loopType: 'forEach', collection: 'items', itemVar: 'item' },
+        },
+        {
+          id: 'par',
+          type: 'parallel',
+          name: 'translate',
+          position: { x: 0, y: 0 },
+          version: '1.0.0',
+          provider: 'cloudflare',
+          data: {},
+        },
+        {
+          id: 'title',
+          type: 'step',
+          name: 'title',
+          position: { x: 0, y: 0 },
+          version: '1.0.0',
+          provider: 'cloudflare',
+          data: { code: 'return item.title;' },
+        },
+        {
+          id: 'desc',
+          type: 'step',
+          name: 'description',
+          position: { x: 0, y: 0 },
+          version: '1.0.0',
+          provider: 'cloudflare',
+          data: { code: 'return item.description;' },
+        },
+        {
+          id: 'update',
+          type: 'step',
+          name: 'update',
+          position: { x: 0, y: 0 },
+          version: '1.0.0',
+          provider: 'cloudflare',
+          data: { code: 'return "ok";' },
+        },
+      ],
+      edges: [
+        { id: 'e1', source: 'loop', target: 'par', label: 'body' },
+        { id: 'e2', source: 'par', target: 'title' },
+        { id: 'e3', source: 'par', target: 'desc' },
+        { id: 'e4', source: 'par', target: 'update', label: 'then' },
+      ],
+    }
+
+    const code = generateWorkflow(ir)
+    // The loop's step.do appears before update's step.do — i.e. update is
+    // emitted inside the loop body, not after the loop has closed.
+    const loopIdx = code.indexOf('await step.do("iterate"')
+    const updateIdx = code.indexOf('await step.do(`update')
+    const closeIdx = code.indexOf('return _output;')
+    expect(loopIdx).toBeGreaterThan(-1)
+    expect(updateIdx).toBeGreaterThan(loopIdx)
+    expect(updateIdx).toBeLessThan(closeIdx)
+    // Step name has been suffixed with the loop counter, proving it sits
+    // inside the loop's scope.
+    expect(code).toContain('update [${_loop_i}]')
+  })
 })
 
 describe('generateNodeCode', () => {

--- a/packages/provider-cloudflare/src/__tests__/codegen/generators/step.test.ts
+++ b/packages/provider-cloudflare/src/__tests__/codegen/generators/step.test.ts
@@ -118,4 +118,25 @@ describe('generateStep', () => {
       expect(code).not.toContain('Run')
     })
   })
+
+  describe('inline (workflow mode)', () => {
+    it('emits an async IIFE with const-bound output when `data.inline` is true', () => {
+      const code = generateStep(makeNode({ data: { code: 'return 42;', inline: true } }))
+      expect(code).not.toContain('step.do')
+      expect(code).toContain('const step_1 = await (async () => {')
+      expect(code).toContain('return 42;')
+      expect(code).toMatch(/}\)\(\);$/)
+    })
+
+    it('omits the const prefix when the inline code has no return', () => {
+      const code = generateStep(makeNode({ data: { code: 'console.log("x");', inline: true } }))
+      expect(code).not.toContain('const step_1')
+      expect(code).toMatch(/^await \(async \(\) => \{/)
+    })
+
+    it('ignores `data.inline` in script mode (script is already inline)', () => {
+      const code = generateStep(makeNode({ data: { code: 'return 1;', inline: true } }), 'script')
+      expect(code).toBe('return 1;')
+    })
+  })
 })

--- a/packages/provider-cloudflare/src/codegen/generators/branch.ts
+++ b/packages/provider-cloudflare/src/codegen/generators/branch.ts
@@ -54,7 +54,7 @@ export function collectBranchInlineTargets(ir: WorkflowIR): Set<string> {
         : ir.edges.filter((e) => e.source === node.id && e.label !== 'then').map((e) => e.target)
 
     for (const target of targets) {
-      const chain = collectChain(target, ctx.adj, ctx.inDegree, ctx.nodeMap)
+      const chain = collectChain(target, ctx.adj, ctx.inDegree, ctx.nodeMap, ctx.edgeLabels)
       for (const chainNode of chain) {
         inlineTargets.add(chainNode.id)
       }
@@ -72,11 +72,14 @@ export function computeInDegree(ir: WorkflowIR): Map<string, number> {
   return inDegree
 }
 
+const CONTAINER_TYPES = new Set(['branch', 'parallel', 'try_catch', 'loop', 'race'])
+
 export function collectChain(
   startId: string,
   adj: Map<string, string[]>,
   inDegree: Map<string, number>,
   nodeMap: Map<string, WorkflowNode>,
+  edgeLabels: Map<string, Map<string, string | undefined>>,
 ): WorkflowNode[] {
   const chain: WorkflowNode[] = []
   let currentId: string | null = startId
@@ -87,14 +90,27 @@ export function collectChain(
 
     chain.push(node)
 
-    if (
-      node.type === 'branch' ||
-      node.type === 'parallel' ||
-      node.type === 'try_catch' ||
-      node.type === 'loop' ||
-      node.type === 'race'
-    )
+    if (CONTAINER_TYPES.has(node.type)) {
+      // Container's normal successors are emitted by the container's own
+      // generator (branches/body/etc.); the only thing that flows past it in
+      // the parent context is the `then` continuation. Follow it if present
+      // and not a join point — otherwise stop.
+      const labels = edgeLabels.get(currentId)
+      let thenTarget: string | null = null
+      if (labels) {
+        for (const [target, label] of labels) {
+          if (label === 'then') {
+            thenTarget = target
+            break
+          }
+        }
+      }
+      if (thenTarget && (inDegree.get(thenTarget) ?? 0) === 1) {
+        currentId = thenTarget
+        continue
+      }
       break
+    }
 
     const successors: string[] = adj.get(currentId) ?? []
     if (successors.length === 1 && (inDegree.get(successors[0]) ?? 0) === 1) {

--- a/packages/provider-cloudflare/src/codegen/generators/container-utils.ts
+++ b/packages/provider-cloudflare/src/codegen/generators/container-utils.ts
@@ -39,7 +39,7 @@ export function inlineChain(
   ir: WorkflowIR,
   spaces: number,
 ): string {
-  const chain = collectChain(startId, ctx.adj, ctx.inDegree, ctx.nodeMap)
+  const chain = collectChain(startId, ctx.adj, ctx.inDegree, ctx.nodeMap, ctx.edgeLabels)
   return chain
     .map((n) => {
       const code = generateNode(n, ir)
@@ -81,7 +81,7 @@ export function generatePromiseContainer(
 
   const branches = targets
     .map((targetId) => {
-      const chain = collectChain(targetId, ctx.adj, ctx.inDegree, ctx.nodeMap)
+      const chain = collectChain(targetId, ctx.adj, ctx.inDegree, ctx.nodeMap, ctx.edgeLabels)
       if (chain.length === 0) return null
       const code = chain.map((n) => generateNode(n, ir)).join('\n')
       return `    async () => {\n${indentCode(code, 6)}\n    }`

--- a/packages/provider-cloudflare/src/codegen/generators/loop.ts
+++ b/packages/provider-cloudflare/src/codegen/generators/loop.ts
@@ -27,7 +27,7 @@ export function generateLoop(
 
   const bodyEdge = ir.edges.find((e) => e.source === node.id && e.label === 'body')
   const bodyChain = bodyEdge
-    ? collectChain(bodyEdge.target, ctx.adj, ctx.inDegree, ctx.nodeMap)
+    ? collectChain(bodyEdge.target, ctx.adj, ctx.inDegree, ctx.nodeMap, ctx.edgeLabels)
     : []
 
   const loopType = node.data.loopType as string

--- a/packages/provider-cloudflare/src/codegen/generators/step.ts
+++ b/packages/provider-cloudflare/src/codegen/generators/step.ts
@@ -43,10 +43,19 @@ export function generateStep(node: WorkflowNode, mode: GenerateMode = 'workflow'
     // To expose on graph, name the node `EXPORT_X` and declare `const X = ...`.
     return code
   }
-  const config = generateStepConfig(resolveStepConfig(node))
-  const configArg = config ? `, ${config}` : ''
   const hasReturn = /\breturn\b/.test(code)
   const prefix = hasReturn ? `const ${varName(node.id)} = ` : ''
+  if (node.data.inline === true) {
+    // Inline steps skip the durable `step.do` wrap — user code runs as a
+    // bare async IIFE in the workflow body. Trades durability/retries for
+    // raw-code ergonomics; appropriate for pure transforms or quick checks
+    // that don't need to be cached/resumed.
+    return `${prefix}await (async () => {
+  ${code}
+})();`
+  }
+  const config = generateStepConfig(resolveStepConfig(node))
+  const configArg = config ? `, ${config}` : ''
   return `${prefix}await step.do("${escName(node.name)}"${configArg}, async () => {
   ${code}
 });`


### PR DESCRIPTION
## Summary
Two related changes shipped together — both touch step/container codegen.

### 1. Fix: container `then` continuation lost when nested in another container
`collectChain` broke as soon as it hit a container (branch / parallel / race / try_catch / loop), dropping any node attached via the container's `then` continuation. With a parallel inside a loop body, the continuation was both omitted from the loop body and emitted as a sibling step at the workflow root.

The walker now follows the `then` edge if its target has in-degree 1, matching the semantic that "a container's `then` is its successor in the parent context". Joins (in-degree > 1) still stop the walk so they're emitted by their topological owner.

Regression test asserts a loop > parallel > then-step shape produces the continuation inside the loop body with the per-iteration counter suffix (`update [${'$'}{_loop_i}]`).

### 2. Feat: inline step toggle (no `step.do` wrap)
New `inline` boolean on step nodes. When enabled in workflow mode, the user's code is emitted as `await (async () => { ... })()` directly in the workflow body. Trades durability and retries for raw-code ergonomics — appropriate for pure transforms or quick checks.

UI rules per request:
- Inline toggle is hidden when `kind === 'script'` (no-op there — script already inline).
- `retryLimit` / `retryDelay` / `backoff` / `timeout` are hidden whenever the step is inline OR the kind is `script`.

## Test plan
- [ ] Build a loop containing a parallel with a `then`-connected follow-up node — continuation lands inside the loop body, runs once per iteration.
- [ ] Same shape but with branch instead of loop — continuation lands inside the branch arm.
- [ ] Toggle a step's `inline` in a workflow — generated code shows `await (async () => { ... })()`, no `step.do`. Retry/timeout fields disappear from the config drawer.
- [ ] Switch the workflow to `script` kind — inline toggle vanishes from step config; retry/timeout fields stay hidden.
- [ ] Switch back to `workflow` — toggle reappears.