### PR TITLE
feat(canvas): auto-save + inline-step / parallel-branch codegen fixes

### DIFF
--- a/apps/web/src/components/canvas/editor-toolbar.tsx
+++ b/apps/web/src/components/canvas/editor-toolbar.tsx
@@ -8,10 +8,12 @@ import {
   Rocket,
   Loader2,
   Save,
-  Circle,
   LayoutTemplate,
   Terminal,
   Download,
+  Check,
+  AlertCircle,
+  Circle,
 } from 'lucide-react'
 import { Button } from '../ui/button'
 import { cn } from '../../lib/utils'
@@ -34,6 +36,8 @@ export interface EditorToolbarProps {
   onToggleEditor: () => void
   onSave: () => void
   isSaving: boolean
+  lastSavedAt?: Date | null
+  autoSaveError?: string | null
   onDeploy: () => void
   onTest: () => void
   onTestLocally?: () => void
@@ -41,6 +45,58 @@ export interface EditorToolbarProps {
   onExport?: () => void
   readOnly?: boolean
   readOnlyVersion?: number
+}
+
+function SaveStatusIndicator({
+  isDirty,
+  isSaving,
+  lastSavedAt,
+  autoSaveError,
+}: {
+  isDirty: boolean
+  isSaving: boolean
+  lastSavedAt: Date | null
+  autoSaveError: string | null
+}) {
+  if (isSaving) {
+    return (
+      <span className="inline-flex items-center gap-1 text-xs text-muted-foreground">
+        <Loader2 className="h-3 w-3 animate-spin" />
+        Saving…
+      </span>
+    )
+  }
+  if (autoSaveError && isDirty) {
+    return (
+      <span
+        className="inline-flex items-center gap-1 text-xs text-destructive"
+        title={autoSaveError}
+      >
+        <AlertCircle className="h-3 w-3" />
+        Couldn&apos;t auto-save
+      </span>
+    )
+  }
+  if (isDirty) {
+    return (
+      <span className="inline-flex items-center gap-1 text-xs text-status-warning">
+        <Circle className="h-2 w-2 fill-status-warning text-status-warning" />
+        Unsaved
+      </span>
+    )
+  }
+  if (lastSavedAt) {
+    return (
+      <span
+        className="inline-flex items-center gap-1 text-xs text-muted-foreground"
+        title={`Saved at ${lastSavedAt.toLocaleTimeString()}`}
+      >
+        <Check className="h-3 w-3 text-status-success" />
+        Saved
+      </span>
+    )
+  }
+  return null
 }
 
 export function EditorToolbar({
@@ -60,6 +116,8 @@ export function EditorToolbar({
   onToggleEditor,
   onSave,
   isSaving,
+  lastSavedAt,
+  autoSaveError,
   onDeploy,
   onTest,
   onTestLocally,
@@ -117,7 +175,12 @@ export function EditorToolbar({
                 : `deployed v${currentVersion}`}
             </Link>
           )}
-          {isDirty && <Circle className="h-2 w-2 fill-status-warning text-status-warning" />}
+          <SaveStatusIndicator
+            isDirty={isDirty}
+            isSaving={isSaving}
+            lastSavedAt={lastSavedAt ?? null}
+            autoSaveError={autoSaveError ?? null}
+          />
         </div>
       </div>
 

--- a/apps/web/src/hooks/use-auto-save.ts
+++ b/apps/web/src/hooks/use-auto-save.ts
@@ -1,0 +1,45 @@
+import { useEffect, useRef } from 'react'
+import { useShallow } from 'zustand/react/shallow'
+import { useWorkflowStore } from '../stores/workflow-store'
+import type { AutoSaveOutcome } from './use-workflow-persistence'
+
+interface UseAutoSaveOpts {
+  enabled: boolean
+  delayMs?: number
+  save: () => Promise<AutoSaveOutcome>
+}
+
+/**
+ * Debounced auto-save: schedules `save()` `delayMs` after the last meaningful
+ * change to the workflow store, and resets the timer on each subsequent change
+ * while still dirty. The watched slice excludes selection state so simply
+ * clicking a node does not push back the save.
+ *
+ * Cancels the timer when the workflow becomes clean (e.g. after a manual save)
+ * or when `enabled` flips to false (read-only / new workflows).
+ */
+export function useAutoSave({ enabled, delayMs = 30_000, save }: UseAutoSaveOpts) {
+  const saveRef = useRef(save)
+  saveRef.current = save
+
+  const watched = useWorkflowStore(
+    useShallow((s) => ({
+      isDirty: s.isDirty,
+      nodes: s.nodes,
+      edges: s.edges,
+      metadata: s.metadata,
+      workflowEnvVars: s.workflowEnvVars,
+      dependencies: s.dependencies,
+      triggerCode: s.triggerCode,
+      deployConfig: s.deployConfig,
+    })),
+  )
+
+  useEffect(() => {
+    if (!enabled || !watched.isDirty) return
+    const timer = setTimeout(() => {
+      void saveRef.current()
+    }, delayMs)
+    return () => clearTimeout(timer)
+  }, [enabled, delayMs, watched])
+}

--- a/apps/web/src/hooks/use-workflow-persistence.ts
+++ b/apps/web/src/hooks/use-workflow-persistence.ts
@@ -1,4 +1,4 @@
-import { useCallback } from 'react'
+import { useCallback, useState } from 'react'
 import { useMutation, useQueryClient } from '@tanstack/react-query'
 import { useNavigate } from '@tanstack/react-router'
 import { toast } from 'sonner'
@@ -7,6 +7,8 @@ import { validateWorkflowForPublish } from '../lib/validate-workflow'
 import { buildIRFromState } from '../lib/build-ir'
 import { api, type WorkflowSummary } from '../lib/api-client'
 import type { NodeRegistry } from '@awaitstep/ir'
+
+export type AutoSaveOutcome = 'saved' | 'skipped' | 'failed'
 
 export function useWorkflowPersistence(opts: {
   workflowId: string
@@ -20,51 +22,55 @@ export function useWorkflowPersistence(opts: {
   const queryClient = useQueryClient()
   const navigate = useNavigate()
   const { markClean, setWorkflowId, runValidation } = useWorkflowStore()
+  const [lastSavedAt, setLastSavedAt] = useState<Date | null>(null)
+  const [autoSaveError, setAutoSaveError] = useState<string | null>(null)
+  const [isAutoSaving, setIsAutoSaving] = useState(false)
 
-  const saveMutation = useMutation({
-    mutationFn: async () => {
-      const state = useWorkflowStore.getState()
-      const ir = buildIRFromState(state)
+  const performSave = useCallback(async (): Promise<WorkflowSummary | null> => {
+    const state = useWorkflowStore.getState()
+    const ir = buildIRFromState(state)
 
-      const SECRET_PREFIX = 'SECRET_'
-      const envVars = state.workflowEnvVars.map((v) => {
-        if (v.name.startsWith(SECRET_PREFIX)) {
-          return { name: v.name.slice(SECRET_PREFIX.length), value: v.value, isSecret: true }
-        }
-        return { name: v.name, value: v.value, isSecret: false }
-      })
-      const triggerCode = state.triggerCode || undefined
-      const dependencies =
-        Object.keys(state.dependencies).length > 0 ? state.dependencies : undefined
-      const deployConfig = state.deployConfig.route ? state.deployConfig : undefined
-
-      if (isNew) {
-        const created = await api.createWorkflow({
-          name: state.metadata.name,
-          description: state.metadata.description,
-          kind,
-        })
-        if (envVars || triggerCode || dependencies || deployConfig) {
-          await api.updateWorkflow(created.id, { envVars, triggerCode, dependencies, deployConfig })
-        }
-        await api.createVersion(created.id, { ir })
-        return created
+    const SECRET_PREFIX = 'SECRET_'
+    const envVars = state.workflowEnvVars.map((v) => {
+      if (v.name.startsWith(SECRET_PREFIX)) {
+        return { name: v.name.slice(SECRET_PREFIX.length), value: v.value, isSecret: true }
       }
+      return { name: v.name, value: v.value, isSecret: false }
+    })
+    const triggerCode = state.triggerCode || undefined
+    const dependencies = Object.keys(state.dependencies).length > 0 ? state.dependencies : undefined
+    const deployConfig = state.deployConfig.route ? state.deployConfig : undefined
 
-      await api.updateWorkflow(workflowId, {
+    if (isNew) {
+      const created = await api.createWorkflow({
         name: state.metadata.name,
         description: state.metadata.description,
-        envVars,
-        triggerCode,
-        dependencies,
-        deployConfig,
+        kind,
       })
-      await api.createVersion(workflowId, { ir })
-      return null
-    },
-    onSuccess: (created: WorkflowSummary | null) => {
+      if (envVars || triggerCode || dependencies || deployConfig) {
+        await api.updateWorkflow(created.id, { envVars, triggerCode, dependencies, deployConfig })
+      }
+      await api.createVersion(created.id, { ir })
+      return created
+    }
+
+    await api.updateWorkflow(workflowId, {
+      name: state.metadata.name,
+      description: state.metadata.description,
+      envVars,
+      triggerCode,
+      dependencies,
+      deployConfig,
+    })
+    await api.createVersion(workflowId, { ir })
+    return null
+  }, [isNew, kind, workflowId])
+
+  const onSaveSuccess = useCallback(
+    (created: WorkflowSummary | null) => {
       markClean()
-      toast.success('Workflow saved')
+      setLastSavedAt(new Date())
+      setAutoSaveError(null)
       queryClient.invalidateQueries({ queryKey: ['workflow-full', workflowId] })
       if (created) {
         window.history.replaceState(null, '', `/workflows/${created.id}/canvas`)
@@ -73,6 +79,15 @@ export function useWorkflowPersistence(opts: {
           queryClient.invalidateQueries({ queryKey: ['workflows'] })
         }
       }
+    },
+    [markClean, queryClient, workflowId, setWorkflowId, isNew],
+  )
+
+  const saveMutation = useMutation({
+    mutationFn: performSave,
+    onSuccess: (created) => {
+      onSaveSuccess(created)
+      toast.success('Workflow saved')
     },
     onError: (err) => {
       toast.error(err instanceof Error ? err.message : 'Failed to save workflow')
@@ -102,6 +117,31 @@ export function useWorkflowPersistence(opts: {
     saveMutation.mutate()
   }, [saveMutation])
 
+  const saveSilent = useCallback(async (): Promise<AutoSaveOutcome> => {
+    const state = useWorkflowStore.getState()
+    const result = validateWorkflowForPublish(
+      state.metadata,
+      state.nodes,
+      state.edges,
+      undefined,
+      { workflowEnvVars: state.workflowEnvVars },
+      state.kind,
+    )
+    // Skip silently on validation errors — manual Save will surface them.
+    if (!result.canPublish) return 'skipped'
+    setIsAutoSaving(true)
+    try {
+      const created = await performSave()
+      onSaveSuccess(created)
+      return 'saved'
+    } catch (err) {
+      setAutoSaveError(err instanceof Error ? err.message : 'Failed to save workflow')
+      return 'failed'
+    } finally {
+      setIsAutoSaving(false)
+    }
+  }, [performSave, onSaveSuccess])
+
   const handleDeploy = useCallback(async () => {
     const result = runValidation(nodeRegistry ?? undefined)
     if (!result.canPublish) {
@@ -130,6 +170,9 @@ export function useWorkflowPersistence(opts: {
   return {
     handleSave,
     handleDeploy,
-    isSaving: saveMutation.isPending,
+    saveSilent,
+    isSaving: saveMutation.isPending || isAutoSaving,
+    lastSavedAt,
+    autoSaveError,
   }
 }

--- a/apps/web/src/routes/_authed/workflows/$workflowId.canvas.tsx
+++ b/apps/web/src/routes/_authed/workflows/$workflowId.canvas.tsx
@@ -24,6 +24,7 @@ import {
   deriveDeploymentState,
 } from '../../../lib/hydrate-workflow'
 import { useWorkflowPersistence } from '../../../hooks/use-workflow-persistence'
+import { useAutoSave } from '../../../hooks/use-auto-save'
 import { buildIRFromState } from '../../../lib/build-ir'
 import { serializeArtifact } from '@awaitstep/ir'
 import { downloadJsonFile } from '../../../lib/download-file'
@@ -166,12 +167,21 @@ function WorkflowEditorPage() {
   }, [workflowId, isNew, kindParam, fullData, setWorkflowId, isReadOnly, currentVersion])
 
   // Persistence (save + deploy)
-  const { handleSave, handleDeploy, isSaving } = useWorkflowPersistence({
-    workflowId,
-    isNew,
-    isDirty,
-    nodeRegistry,
-    kind: kindParam,
+  const { handleSave, handleDeploy, saveSilent, isSaving, lastSavedAt, autoSaveError } =
+    useWorkflowPersistence({
+      workflowId,
+      isNew,
+      isDirty,
+      nodeRegistry,
+      kind: kindParam,
+    })
+
+  // Auto-save 30s after the last meaningful change. Skipped on read-only
+  // workflows and on never-saved workflows (so a stray drag on /new doesn't
+  // create a phantom workflow).
+  useAutoSave({
+    enabled: !isReadOnly && !isNew,
+    save: saveSilent,
   })
 
   const handleAddNode = (type: Parameters<typeof addNode>[0]) => {
@@ -212,6 +222,8 @@ function WorkflowEditorPage() {
                 onToggleEditor={() => setShowEditor(!showEditor)}
                 onSave={handleSave}
                 isSaving={isSaving}
+                lastSavedAt={lastSavedAt}
+                autoSaveError={autoSaveError}
                 onDeploy={handleDeploy}
                 onTest={() => runSimulation()}
                 onTestLocally={localDevEnabled ? () => setShowLocalTest((v) => !v) : undefined}

--- a/packages/ir/src/bundled-nodes/step.ts
+++ b/packages/ir/src/bundled-nodes/step.ts
@@ -21,7 +21,7 @@ export const stepDefinition: NodeDefinition = {
       label: 'Inline (no step.do)',
       default: false,
       description:
-        'Emit this code directly in the workflow body instead of wrapping it in step.do. Loses durability and retries — use for pure transforms or quick checks.',
+        'Emit this code raw in the workflow body — no step.do, no wrapping. You own the surrounding scope: declare your own variables, add your own try/catch or IIFE if needed. Loses durability and retries.',
     },
     retryLimit: {
       type: 'number',

--- a/packages/provider-cloudflare/src/__tests__/codegen/generators/parallel.test.ts
+++ b/packages/provider-cloudflare/src/__tests__/codegen/generators/parallel.test.ts
@@ -116,4 +116,55 @@ describe('generateParallel', () => {
     expect(code).toContain('await step.do("Run in parallel"')
     expect(code).toContain('return await Promise.allSettled')
   })
+
+  it('returns each branch step variable so allSettled values are usable', () => {
+    // Regression: branches of `async () => { const X = await step.do(...) }`
+    // had no return statement, so allSettled resolved every branch to
+    // `undefined`. Branches that bind a variable (i.e. step has `return` in
+    // body) must surface that var as the branch's promise value.
+    const ir = makeIR([
+      {
+        id: 'title',
+        type: 'step',
+        name: 'title',
+        position: { x: 0, y: 0 },
+        version: V,
+        provider: P,
+        data: { code: 'return listing.title;' },
+      },
+      {
+        id: 'desc',
+        type: 'step',
+        name: 'description',
+        position: { x: 0, y: 0 },
+        version: V,
+        provider: P,
+        data: { code: 'return listing.description;' },
+      },
+    ])
+    const node = ir.nodes[0]!
+    const code = generateParallel(node, ir, generateNodeCode)
+    expect(code).toContain('return title;')
+    expect(code).toContain('return desc;')
+  })
+
+  it('omits return for side-effect-only branch steps', () => {
+    // Step nodes without a `return` in their code don't get a `const X =`
+    // prefix, so there's nothing meaningful to surface; the branch resolves
+    // to undefined as before.
+    const ir = makeIR([
+      {
+        id: 'log',
+        type: 'step',
+        name: 'log',
+        position: { x: 0, y: 0 },
+        version: V,
+        provider: P,
+        data: { code: 'console.log("noop");' },
+      },
+    ])
+    const node = ir.nodes[0]!
+    const code = generateParallel(node, ir, generateNodeCode)
+    expect(code).not.toMatch(/return\s+log\b/)
+  })
 })

--- a/packages/provider-cloudflare/src/__tests__/codegen/generators/step.test.ts
+++ b/packages/provider-cloudflare/src/__tests__/codegen/generators/step.test.ts
@@ -120,18 +120,25 @@ describe('generateStep', () => {
   })
 
   describe('inline (workflow mode)', () => {
-    it('emits an async IIFE with const-bound output when `data.inline` is true', () => {
+    it('emits raw user code with no wrapping when `data.inline` is true', () => {
       const code = generateStep(makeNode({ data: { code: 'return 42;', inline: true } }))
-      expect(code).not.toContain('step.do')
-      expect(code).toContain('const step_1 = await (async () => {')
-      expect(code).toContain('return 42;')
-      expect(code).toMatch(/}\)\(\);$/)
+      expect(code).toBe('return 42;')
     })
 
-    it('omits the const prefix when the inline code has no return', () => {
-      const code = generateStep(makeNode({ data: { code: 'console.log("x");', inline: true } }))
+    it('emits side-effect-only inline code unchanged', () => {
+      const code = generateStep(
+        makeNode({
+          data: { code: '_output = [..._output, listing];', inline: true },
+        }),
+      )
+      expect(code).toBe('_output = [..._output, listing];')
+    })
+
+    it('does not add a const prefix or step.do wrap for inline', () => {
+      const code = generateStep(makeNode({ data: { code: 'return x;', inline: true } }))
       expect(code).not.toContain('const step_1')
-      expect(code).toMatch(/^await \(async \(\) => \{/)
+      expect(code).not.toContain('step.do')
+      expect(code).not.toContain('async () =>')
     })
 
     it('ignores `data.inline` in script mode (script is already inline)', () => {

--- a/packages/provider-cloudflare/src/codegen/generators/container-utils.ts
+++ b/packages/provider-cloudflare/src/codegen/generators/container-utils.ts
@@ -84,7 +84,15 @@ export function generatePromiseContainer(
       const chain = collectChain(targetId, ctx.adj, ctx.inDegree, ctx.nodeMap, ctx.edgeLabels)
       if (chain.length === 0) return null
       const code = chain.map((n) => generateNode(n, ir)).join('\n')
-      return `    async () => {\n${indentCode(code, 6)}\n    }`
+      // If the last node in the branch bound a variable, surface it as the
+      // branch's promise value so callers can destructure it from
+      // Promise.all / allSettled / race results. Side-effect-only nodes get
+      // no return — the branch resolves to undefined as before.
+      const lastNode = chain[chain.length - 1]!
+      const lastVar = varName(lastNode.id)
+      const declRe = new RegExp(`(?:^|\\n)\\s*(?:let|const)\\s+${lastVar}\\b`)
+      const tail = declRe.test(code) ? `\n      return ${lastVar};` : ''
+      return `    async () => {\n${indentCode(code, 6)}${tail}\n    }`
     })
     .filter(Boolean)
 

--- a/packages/provider-cloudflare/src/codegen/generators/step.ts
+++ b/packages/provider-cloudflare/src/codegen/generators/step.ts
@@ -37,23 +37,16 @@ function resolveStepConfig(node: WorkflowNode): StepConfig | undefined {
 
 export function generateStep(node: WorkflowNode, mode: GenerateMode = 'workflow'): string {
   const code = String(node.data.code ?? '')
-  if (mode === 'script') {
-    // Step code is inlined raw into `runGraph`. `return X` exits runGraph
-    // with X. To share values across steps, declare `const myVar = ...`.
-    // To expose on graph, name the node `EXPORT_X` and declare `const X = ...`.
+  // Inline steps (and script mode) emit raw user code with no wrapping.
+  // The user owns the surrounding scope: they can mutate enclosing `let`s,
+  // declare local vars, and add their own IIFE if they want one. To share a
+  // value with downstream nodes, declare `const X = ...` matching the
+  // sanitized node id.
+  if (mode === 'script' || node.data.inline === true) {
     return code
   }
   const hasReturn = /\breturn\b/.test(code)
   const prefix = hasReturn ? `const ${varName(node.id)} = ` : ''
-  if (node.data.inline === true) {
-    // Inline steps skip the durable `step.do` wrap — user code runs as a
-    // bare async IIFE in the workflow body. Trades durability/retries for
-    // raw-code ergonomics; appropriate for pure transforms or quick checks
-    // that don't need to be cached/resumed.
-    return `${prefix}await (async () => {
-  ${code}
-})();`
-  }
   const config = generateStepConfig(resolveStepConfig(node))
   const configArg = config ? `, ${config}` : ''
   return `${prefix}await step.do("${escName(node.name)}"${configArg}, async () => {


### PR DESCRIPTION
## Summary
Three independent changes, branched off `main` and bundled in one PR.

### 1. feat(canvas): auto-save 30s after last meaningful change
- New `useAutoSave` hook subscribes to the meaningful workflow slice (`isDirty`, `nodes`, `edges`, `metadata`, `workflowEnvVars`, `dependencies`, `triggerCode`, `deployConfig`). Selection is excluded so clicking nodes doesn't push back the save.
- Skipped on read-only versions and on never-saved workflows (so a stray drag on `/new` doesn't create a phantom row).
- Validation runs **silently** — failures defer the save quietly. Manual Save still surfaces every error as before.
- Network failures aren't toasted on auto-save either; they show up in the new toolbar status indicator instead.
- The toolbar's lone dirty dot is replaced by a `SaveStatusIndicator` cycling through `Saving…` (spinner), `Couldn't auto-save` (red, hover for error), `Unsaved` (amber dot), and `Saved` (green check, hover for timestamp).
- `useWorkflowPersistence` refactored: extracted `performSave`, added `saveSilent`, `lastSavedAt`, `autoSaveError`, and a unified `isSaving` covering both manual and auto saves.

### 2. fix(codegen): emit inline step body raw, no IIFE wrap
Inline workflow steps were wrapped in `await (async () => { ... })()`. Now they emit raw, matching script-mode exactly. The user owns the surrounding scope and can mutate enclosing `let`s (loop accumulators, hoisted output captures), declare local vars, or add their own IIFE only when needed.

### 3. fix(codegen): return last bound variable from parallel / race branches
Each branch in `Promise.allSettled([...])` (and the race variant) was emitted as `async () => { const X = await step.do(...) }` with no return — every branch resolved to `undefined`, so `[a, b] = parallelResult` destructuring got back undefined. Now: when the last node in a branch chain bound a variable, append `return X;` so the branch resolves to that value. Side-effect-only last nodes still resolve to undefined.

## Test plan
- [ ] Edit a node on an existing workflow, wait 30s — toolbar shows `Saving…` then `Saved`. Refresh: changes persisted.
- [ ] Edit, wait 25s, edit again — timer resets, single save fires 30s after the second edit.
- [ ] On `/workflows/new`, drag a node, wait — no auto-save fires (no phantom workflow created).
- [ ] Open a versioned (read-only) view — no auto-save, no indicator changes from `Unsaved`.
- [ ] Toggle a step to **Inline** in a workflow — generated code shows the user's body raw, no `step.do`, no IIFE, no const prefix; you can mutate enclosing `_output` directly.
- [ ] Build a parallel of two steps that each `return` — generated `Promise.allSettled` branches contain `return <var>;` and destructured values flow through correctly.
- [ ] Build a parallel where one branch is side-effect-only (no `return` in body) — that branch still emits no `return` line.