### PR TITLE
feat(codegen): @scheduled annotation with @crons block

### DIFF
--- a/packages/provider-cloudflare/src/__tests__/adapter.test.ts
+++ b/packages/provider-cloudflare/src/__tests__/adapter.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, vi } from 'vitest'
 import type { WorkflowIR } from '@awaitstep/ir'
 import type { ProviderConfig } from '@awaitstep/codegen'
-import { CloudflareWorkflowsAdapter, buildQueueConsumers } from '../adapter.js'
+import { CloudflareWorkflowsAdapter, buildQueueConsumers, buildCronTriggers } from '../adapter.js'
 import type { WranglerDeployer } from '../deploy/deployer.js'
 
 const mockDeployer: WranglerDeployer = {
@@ -367,5 +367,57 @@ describe('buildQueueConsumers', () => {
       { queue: 'emails', maxBatchSize: 50 },
       { queue: 'jobs', maxBatchSize: 1, maxConcurrency: 20 },
     ])
+  })
+})
+
+describe('buildCronTriggers', () => {
+  it('returns undefined when neither annotations nor config provide crons', () => {
+    expect(buildCronTriggers(undefined, undefined)).toBeUndefined()
+    expect(
+      buildCronTriggers('try { return new Response() } catch(e) {}', undefined),
+    ).toBeUndefined()
+  })
+
+  it('extracts crons from a single @scheduled handler', () => {
+    const triggerCode = `
+@scheduled function nightly(controller, env, ctx) {
+  @crons ["0 2 * * *"]
+}
+`
+    expect(buildCronTriggers(triggerCode, undefined)).toEqual(['0 2 * * *'])
+  })
+
+  it('unions crons from multiple @scheduled handlers in declaration order', () => {
+    const triggerCode = `
+@scheduled function morning(controller, env, ctx) {
+  @crons ["0 6 * * *"]
+}
+
+@scheduled function evening(controller, env, ctx) {
+  @crons ["0 18 * * *", "0 20 * * *"]
+}
+`
+    expect(buildCronTriggers(triggerCode, undefined)).toEqual([
+      '0 6 * * *',
+      '0 18 * * *',
+      '0 20 * * *',
+    ])
+  })
+
+  it('merges deploymentConfig.cronTriggers with annotation crons (annotations first, dedup)', () => {
+    const triggerCode = `
+@scheduled function nightly(controller, env, ctx) {
+  @crons ["0 2 * * *"]
+}
+`
+    const result = buildCronTriggers(triggerCode, {
+      cronTriggers: ['0 2 * * *', '*/15 * * * *'],
+    })
+    // "0 2 * * *" appears once even though both sources list it.
+    expect(result).toEqual(['0 2 * * *', '*/15 * * * *'])
+  })
+
+  it('uses deploymentConfig.cronTriggers when no annotation handlers are declared', () => {
+    expect(buildCronTriggers(undefined, { cronTriggers: ['0 0 * * *'] })).toEqual(['0 0 * * *'])
   })
 })

--- a/packages/provider-cloudflare/src/__tests__/codegen/generate.test.ts
+++ b/packages/provider-cloudflare/src/__tests__/codegen/generate.test.ts
@@ -531,4 +531,52 @@ function shared(x) { return x }
     expect(code).toContain('async fetch(request: Request, env: Env): Promise<Response>')
     expect(code).not.toContain('async queue(')
   })
+
+  it('emits a scheduled handler when @scheduled is declared', () => {
+    const triggerCode = `
+@fetch function handler(request, env, ctx) {
+  return Response.json({ ok: true })
+}
+
+@scheduled function nightly(controller, env, ctx) {
+  @crons ["0 2 * * *", "0 14 * * *"]
+  console.log("ran at", controller.scheduledTime)
+}
+`
+    const code = generateWorkflow(ir, { triggerCode })
+    expect(code).toMatch(
+      /async scheduled\(controller: ScheduledController, env: Env, ctx: ExecutionContext\): Promise<void>/,
+    )
+    expect(code).toContain('switch (controller.cron)')
+    expect(code).toContain('case "0 2 * * *":')
+    expect(code).toContain('case "0 14 * * *":')
+    expect(code).toContain('console.log("ran at", controller.scheduledTime)')
+    // Body emitted only once for the two-cron handler (case fallthrough).
+    expect(code.match(/console\.log\("ran at"/g)?.length ?? 0).toBe(1)
+  })
+
+  it('emits one case per cron across multiple @scheduled handlers', () => {
+    const triggerCode = `
+@scheduled function morning(controller, env, ctx) {
+  @crons ["0 6 * * *"]
+  console.log("morning")
+}
+
+@scheduled function evening(controller, env, ctx) {
+  @crons ["0 18 * * *"]
+  console.log("evening")
+}
+`
+    const code = generateWorkflow(ir, { triggerCode })
+    expect(code).toContain('case "0 6 * * *":')
+    expect(code).toContain('case "0 18 * * *":')
+    expect(code).toContain('console.log("morning")')
+    expect(code).toContain('console.log("evening")')
+  })
+
+  it('omits scheduled handler when no @scheduled is declared', () => {
+    const triggerCode = `@fetch function handler(req, env) { return new Response("ok") }`
+    const code = generateWorkflow(ir, { triggerCode })
+    expect(code).not.toContain('async scheduled(')
+  })
 })

--- a/packages/provider-cloudflare/src/__tests__/codegen/parse-annotations.test.ts
+++ b/packages/provider-cloudflare/src/__tests__/codegen/parse-annotations.test.ts
@@ -258,8 +258,8 @@ describe('parseAnnotations — placement validation', () => {
 describe('parseAnnotations — entry-point validation', () => {
   it('rejects strict mode with no handlers (annotation but unsupported kind)', () => {
     // Only one annotation, and it's invalid kind — gets rejected before "no entry point".
-    const source = `@scheduled function cron(event, env, ctx) {}`
-    expect(() => parseAnnotations(source)).toThrow(/Unknown annotation '@scheduled'/)
+    const source = `@durable function thing(event, env, ctx) {}`
+    expect(() => parseAnnotations(source)).toThrow(/Unknown annotation '@durable'/)
   })
 
   it('queue-only worker is valid (no @fetch required)', () => {
@@ -302,8 +302,8 @@ describe('parseAnnotations — error messages include line numbers', () => {
 
 describe('parseAnnotations — unsupported annotations', () => {
   it('rejects unknown annotation kinds', () => {
-    const source = `@scheduled function cron(event, env, ctx) {}`
-    expect(() => parseAnnotations(source)).toThrow(/Unknown annotation '@scheduled'/)
+    const source = `@durable function thing(event, env, ctx) {}`
+    expect(() => parseAnnotations(source)).toThrow(/Unknown annotation '@durable'/)
   })
 })
 
@@ -407,5 +407,112 @@ describe('parseAnnotations — @config block in @queue handler', () => {
 }`
     const result = expectStrict(source)
     expect(result.queueHandlers[0]!.config).toEqual({ maxBatchSize: 5 })
+  })
+})
+
+describe('parseAnnotations — @scheduled handler with @crons', () => {
+  it('parses a single @scheduled handler with one cron', () => {
+    const source = `@scheduled function nightly(controller, env, ctx) {
+  @crons ["0 2 * * *"]
+  console.log("nightly run")
+}`
+    const result = expectStrict(source)
+    expect(result.scheduledHandlers).toHaveLength(1)
+    const sh = result.scheduledHandlers[0]!
+    expect(sh.name).toBe('nightly')
+    expect(sh.crons).toEqual(['0 2 * * *'])
+    expect(sh.body).toContain('console.log("nightly run")')
+    expect(sh.body).not.toContain('@crons')
+  })
+
+  it('parses multiple crons in a single handler', () => {
+    const source = `@scheduled function twice(controller, env, ctx) {
+  @crons ["0 2 * * *", "0 14 * * *"]
+  console.log("twice")
+}`
+    const result = expectStrict(source)
+    expect(result.scheduledHandlers[0]!.crons).toEqual(['0 2 * * *', '0 14 * * *'])
+  })
+
+  it('parses multiple @scheduled handlers', () => {
+    const source = `@scheduled function morning(controller, env, ctx) {
+  @crons ["0 6 * * *"]
+  await env.KV.put("morning", "ran")
+}
+
+@scheduled function evening(controller, env, ctx) {
+  @crons ["0 18 * * *"]
+  await env.KV.put("evening", "ran")
+}`
+    const result = expectStrict(source)
+    expect(result.scheduledHandlers).toHaveLength(2)
+    expect(result.scheduledHandlers[0]!.crons).toEqual(['0 6 * * *'])
+    expect(result.scheduledHandlers[1]!.crons).toEqual(['0 18 * * *'])
+  })
+
+  it('coexists with @fetch and @queue handlers', () => {
+    const source = `@fetch function handler(req, env) { return new Response("ok") }
+@queue function jobs(batch, env) { for (const m of batch.messages) m.ack() }
+@scheduled function nightly(controller, env, ctx) {
+  @crons ["0 0 * * *"]
+  console.log("nightly")
+}`
+    const result = expectStrict(source)
+    expect(result.fetchHandler).toBeDefined()
+    expect(result.queueHandlers).toHaveLength(1)
+    expect(result.scheduledHandlers).toHaveLength(1)
+  })
+
+  it('rejects @scheduled with no @crons block', () => {
+    const source = `@scheduled function nope(controller, env, ctx) {
+  console.log("oops")
+}`
+    expect(() => parseAnnotations(source)).toThrow(/missing required @crons/)
+  })
+
+  it('rejects @scheduled with empty @crons list', () => {
+    const source = `@scheduled function nope(controller, env, ctx) {
+  @crons []
+  console.log("oops")
+}`
+    expect(() => parseAnnotations(source)).toThrow(/at least one cron/)
+  })
+
+  it('rejects @crons with unquoted values', () => {
+    const source = `@scheduled function nope(controller, env, ctx) {
+  @crons [* * * * *]
+  console.log("oops")
+}`
+    expect(() => parseAnnotations(source)).toThrow(/quoted string/)
+  })
+
+  it('rejects duplicate cron expression across handlers', () => {
+    const source = `@scheduled function a(controller, env, ctx) {
+  @crons ["0 0 * * *"]
+}
+
+@scheduled function b(controller, env, ctx) {
+  @crons ["0 0 * * *"]
+}`
+    expect(() => parseAnnotations(source)).toThrow(/already used by @scheduled 'a'/)
+  })
+
+  it('rejects duplicate @scheduled handler name', () => {
+    const source = `@scheduled function dup(controller, env, ctx) {
+  @crons ["0 0 * * *"]
+}
+
+@scheduled function dup(controller, env, ctx) {
+  @crons ["0 12 * * *"]
+}`
+    expect(() => parseAnnotations(source)).toThrow(/Duplicate scheduled handler 'dup'/)
+  })
+
+  it('rejects @crons block placed mid-body', () => {
+    const source = `@scheduled function nope(controller, env, ctx) {
+  console.log("first")
+  @crons ["0 0 * * *"]
+}`
+    expect(() => parseAnnotations(source)).toThrow(/must be at the start/)
   })
 })

--- a/packages/provider-cloudflare/src/adapter.ts
+++ b/packages/provider-cloudflare/src/adapter.ts
@@ -329,6 +329,7 @@ export class CloudflareWorkflowsAdapter implements WorkflowProvider, LocalDevPro
     // `deploymentConfig.queueConsumers` if present; otherwise CF defaults apply.
     const triggerCodeForAnnotations = config.options?.['triggerCode'] as string | undefined
     const queueConsumers = buildQueueConsumers(triggerCodeForAnnotations, deploymentConfig)
+    const cronTriggers = buildCronTriggers(triggerCodeForAnnotations, deploymentConfig)
 
     if (!this.deployer) {
       report('FAILED', 'No deployer configured — deploy is not available on this runtime', 0)
@@ -363,7 +364,7 @@ export class CloudflareWorkflowsAdapter implements WorkflowProvider, LocalDevPro
         customDomains: deploymentConfig?.customDomains,
         compatibilityDate: deploymentConfig?.compatibilityDate,
         compatibilityFlags: deploymentConfig?.compatibilityFlags,
-        cronTriggers: deploymentConfig?.cronTriggers,
+        cronTriggers,
         placement: deploymentConfig?.placement,
         limits: deploymentConfig?.limits,
         observability: deploymentConfig?.observability,
@@ -553,6 +554,48 @@ export function buildQueueConsumers(
       maxConcurrency?: number
     }
   })
+}
+
+/**
+ * Returns the union of cron expressions from `@scheduled` annotations and
+ * any explicit `deploymentConfig.cronTriggers`, deduped while preserving the
+ * order in which they first appear (annotation crons first). Returns
+ * undefined when neither source contributes any cron, so the wrangler config
+ * omits the `triggers` block entirely.
+ *
+ * Annotation parse errors are silently swallowed here — they're already
+ * surfaced by the codegen path that runs first.
+ */
+export function buildCronTriggers(
+  triggerCode: string | undefined,
+  deploymentConfig: CloudflareDeploymentConfig | undefined,
+): string[] | undefined {
+  const seen = new Set<string>()
+  const out: string[] = []
+  if (triggerCode) {
+    try {
+      const parsed = parseAnnotations(triggerCode)
+      if (parsed.mode === 'strict') {
+        for (const sh of parsed.scheduledHandlers) {
+          for (const cron of sh.crons ?? []) {
+            if (!seen.has(cron)) {
+              seen.add(cron)
+              out.push(cron)
+            }
+          }
+        }
+      }
+    } catch {
+      // Ignore — codegen path raises this as a structured DeployResult.
+    }
+  }
+  for (const cron of deploymentConfig?.cronTriggers ?? []) {
+    if (!seen.has(cron)) {
+      seen.add(cron)
+      out.push(cron)
+    }
+  }
+  return out.length > 0 ? out : undefined
 }
 
 export function mapCFStatus(cfStatus: string): WorkflowStatus {

--- a/packages/provider-cloudflare/src/codegen/generate-workflow.ts
+++ b/packages/provider-cloudflare/src/codegen/generate-workflow.ts
@@ -203,6 +203,11 @@ export function generateWorkflow(
     params: string
     body: string
   }> = []
+  const scheduledHandlerEmissions: Array<{
+    name: string
+    crons: string[]
+    body: string
+  }> = []
 
   if (parsed.mode === 'legacy') {
     const { imports, body } = extractImports(parsed.fetchBody)
@@ -226,6 +231,15 @@ export function generateWorkflow(
         name: qh.name,
         queueName: qh.queueName ?? qh.name,
         params: qh.params,
+        body,
+      })
+    }
+    for (const sh of parsed.scheduledHandlers) {
+      const { imports, body } = extractImports(sh.body)
+      collectedImports.push(...imports)
+      scheduledHandlerEmissions.push({
+        name: sh.name,
+        crons: sh.crons ?? [],
         body,
       })
     }
@@ -257,6 +271,24 @@ ${indent(qh.body, 8)}${trailing}
       .join('\n')
     handlerBlocks.push(`  async queue(batch: MessageBatch<unknown>, env: Env, ctx: ExecutionContext): Promise<void> {
     switch (batch.queue) {
+${cases}
+    }
+  },`)
+  }
+  if (scheduledHandlerEmissions.length > 0) {
+    // One case per cron expression; multiple crons that share a handler use
+    // case-fallthrough so the body emits only once per handler.
+    const cases = scheduledHandlerEmissions
+      .map((sh) => {
+        const labels = sh.crons.map((c) => `      case "${c}":`).join('\n')
+        return `${labels} {
+${indent(sh.body, 8)}
+        break;
+      }`
+      })
+      .join('\n')
+    handlerBlocks.push(`  async scheduled(controller: ScheduledController, env: Env, ctx: ExecutionContext): Promise<void> {
+    switch (controller.cron) {
 ${cases}
     }
   },`)

--- a/packages/provider-cloudflare/src/codegen/parse-annotations.ts
+++ b/packages/provider-cloudflare/src/codegen/parse-annotations.ts
@@ -30,6 +30,7 @@ export interface StrictParseResult {
   moduleCode: string
   fetchHandler?: HandlerDecl
   queueHandlers: HandlerDecl[]
+  scheduledHandlers: HandlerDecl[]
 }
 
 export interface HandlerDecl {
@@ -55,6 +56,13 @@ export interface HandlerDecl {
    * `cloudflareInlineQueueConfigSchema`.
    */
   config?: Record<string, string | number | boolean>
+  /**
+   * For `@scheduled` handlers: the cron expressions (as written by the
+   * user) that trigger this handler. Parsed from a leading `@crons
+   * [...]` block. Always at least one — empty lists throw at parse time.
+   * Each cron also lands in wrangler `triggers.crons`.
+   */
+  crons?: string[]
 }
 
 export class AnnotationParseError extends Error {
@@ -66,7 +74,7 @@ export class AnnotationParseError extends Error {
   }
 }
 
-const SUPPORTED_KINDS = new Set(['fetch', 'queue'])
+const SUPPORTED_KINDS = new Set(['fetch', 'queue', 'scheduled'])
 const FETCH_HANDLER_NAME = 'handler'
 const VALID_IDENTIFIER = /^[A-Za-z_$][A-Za-z0-9_$]*$/
 
@@ -91,12 +99,15 @@ export function parseAnnotations(source: string): ParsedTriggerCode {
 function buildStrictResult(source: string, annotations: RawAnnotation[]): StrictParseResult {
   let fetchHandler: HandlerDecl | undefined
   const queueHandlers: HandlerDecl[] = []
+  const scheduledHandlers: HandlerDecl[] = []
   const seenQueueNames = new Set<string>()
+  const seenScheduledNames = new Set<string>()
+  const seenCrons = new Map<string, string>() // cron → handler name
 
   for (const ann of annotations) {
     if (!SUPPORTED_KINDS.has(ann.kind)) {
       throw new AnnotationParseError(
-        `Unknown annotation '@${ann.kind}'. Supported: @fetch, @queue`,
+        `Unknown annotation '@${ann.kind}'. Supported: @fetch, @queue, @scheduled`,
         ann.line,
       )
     }
@@ -131,12 +142,41 @@ function buildStrictResult(source: string, annotations: RawAnnotation[]): Strict
         line: ann.line,
         ...(config && { config }),
       })
+    } else if (ann.kind === 'scheduled') {
+      if (!VALID_IDENTIFIER.test(ann.name)) {
+        throw new AnnotationParseError(
+          `@scheduled function name '${ann.name}' is not a valid identifier`,
+          ann.line,
+        )
+      }
+      if (seenScheduledNames.has(ann.name)) {
+        throw new AnnotationParseError(`Duplicate scheduled handler '${ann.name}'`, ann.line)
+      }
+      seenScheduledNames.add(ann.name)
+      const { crons, cleanedBody } = extractCronsBlock(ann.body, ann.line)
+      for (const cron of crons) {
+        const prior = seenCrons.get(cron)
+        if (prior) {
+          throw new AnnotationParseError(
+            `Cron '${cron}' is already used by @scheduled '${prior}'. Each cron expression can trigger only one handler.`,
+            ann.line,
+          )
+        }
+        seenCrons.set(cron, ann.name)
+      }
+      scheduledHandlers.push({
+        name: ann.name,
+        params: ann.params,
+        body: cleanedBody,
+        line: ann.line,
+        crons,
+      })
     }
   }
 
-  if (!fetchHandler && queueHandlers.length === 0) {
+  if (!fetchHandler && queueHandlers.length === 0 && scheduledHandlers.length === 0) {
     throw new AnnotationParseError(
-      'Workflow has no entry point. Define @fetch function handler(...) or @queue function NAME(...)',
+      'Workflow has no entry point. Define @fetch function handler(...), @queue function NAME(...), or @scheduled function NAME(...)',
       1,
     )
   }
@@ -146,7 +186,7 @@ function buildStrictResult(source: string, annotations: RawAnnotation[]): Strict
     annotations.map((a) => [a.spanStart, a.spanEnd] as const),
   )
 
-  return { mode: 'strict', moduleCode, fetchHandler, queueHandlers }
+  return { mode: 'strict', moduleCode, fetchHandler, queueHandlers, scheduledHandlers }
 }
 
 /**
@@ -594,6 +634,121 @@ function parseConfigValue(s: string, key: string, line: number): string | number
   const n = Number(s)
   if (!Number.isNaN(n) && s !== '') return n
   throw new AnnotationParseError(`@config: cannot parse value '${s}' for '${key}'`, line)
+}
+
+// ────────────────────────────────────────────────────────────
+// @crons block parsing (scheduled handler cron list)
+// ────────────────────────────────────────────────────────────
+
+/**
+ * Looks for a leading `@crons [ ... ]` block in a scheduled handler body.
+ * The block is required, must be at the start of the body, and must contain
+ * at least one non-empty cron expression string.
+ *
+ * Returns the parsed cron list and the body with the block stripped.
+ */
+function extractCronsBlock(
+  body: string,
+  handlerLine: number,
+): {
+  crons: string[]
+  cleanedBody: string
+} {
+  const headerMatch = /^([\s]*)@crons\s*\[/.exec(body)
+  if (!headerMatch) {
+    if (/(^|\n)\s*@crons\s*\[/.test(body)) {
+      throw new AnnotationParseError(
+        '@crons block must be at the start of the scheduled handler body',
+        handlerLine,
+      )
+    }
+    throw new AnnotationParseError(
+      '@scheduled handler is missing required @crons [ ... ] block',
+      handlerLine,
+    )
+  }
+  const openBracketIdx = headerMatch.index + headerMatch[0].length - 1
+  const closeBracketIdx = findCronsCloseBracket(body, openBracketIdx, handlerLine)
+  const inner = body.slice(openBracketIdx + 1, closeBracketIdx)
+
+  const remainder = body.slice(closeBracketIdx + 1)
+  if (/(^|\n)\s*@crons\s*\[/.test(remainder)) {
+    throw new AnnotationParseError('Duplicate @crons block in scheduled handler body', handlerLine)
+  }
+
+  const items = splitTopLevelCommas(inner)
+  const crons: string[] = []
+  for (const raw of items) {
+    const trimmed = raw.trim()
+    if (!trimmed) continue
+    if (
+      !(
+        (trimmed.startsWith('"') && trimmed.endsWith('"')) ||
+        (trimmed.startsWith("'") && trimmed.endsWith("'"))
+      )
+    ) {
+      throw new AnnotationParseError(
+        `@crons: each cron must be a quoted string, got ${trimmed}`,
+        handlerLine,
+      )
+    }
+    const cron = trimmed.slice(1, -1).trim()
+    if (!cron) {
+      throw new AnnotationParseError('@crons: cron expression must be non-empty', handlerLine)
+    }
+    crons.push(cron)
+  }
+  if (crons.length === 0) {
+    throw new AnnotationParseError(
+      '@crons: list must contain at least one cron expression',
+      handlerLine,
+    )
+  }
+
+  const cleanedBody = body.slice(0, headerMatch.index) + remainder
+  return { crons, cleanedBody }
+}
+
+/**
+ * Walks from the opening `[` of a `@crons` block to its matching `]`,
+ * tracking string/comment context so brackets inside string literals
+ * don't confuse the matcher.
+ */
+function findCronsCloseBracket(body: string, openIdx: number, line: number): number {
+  let i = openIdx + 1
+  let depth = 1
+  let inSingle = false
+  let inDouble = false
+  while (i < body.length) {
+    const c = body[i]!
+    if (inSingle) {
+      if (c === '\\' && i + 1 < body.length) {
+        i += 2
+        continue
+      }
+      if (c === "'") inSingle = false
+      i++
+      continue
+    }
+    if (inDouble) {
+      if (c === '\\' && i + 1 < body.length) {
+        i += 2
+        continue
+      }
+      if (c === '"') inDouble = false
+      i++
+      continue
+    }
+    if (c === "'") inSingle = true
+    else if (c === '"') inDouble = true
+    else if (c === '[') depth++
+    else if (c === ']') {
+      depth--
+      if (depth === 0) return i
+    }
+    i++
+  }
+  throw new AnnotationParseError('Unclosed @crons block — missing matching "]"', line)
 }
 
 /** Splits a string by commas at the top level (depth 0 of `{}`, `[]`, `()`). */


### PR DESCRIPTION
## Summary
Adds `@scheduled function NAME(controller, env, ctx)` as a top-level worker annotation alongside `@fetch` and `@queue`. Each scheduled handler must declare a leading `@crons [...]` block listing the cron expressions that trigger it; those crons are emitted into the generated \`async scheduled(...)\` handler as switch cases AND folded into wrangler's \`triggers.crons\`, so a single source of truth wires both the dispatch and the registration.

\`\`\`ts
@scheduled function nightly(controller, env, ctx) {
  @crons [\"0 2 * * *\", \"0 14 * * *\"]
  console.log(\"ran at\", controller.scheduledTime)
}
\`\`\`

### Pieces
- **Parser** (\`parse-annotations.ts\`): \`@scheduled\` joins the supported kinds. New \`extractCronsBlock\` parses the leading \`@crons [ ... ]\` array — quoted strings only, must be non-empty. The block is **required** because CF dispatches the scheduled handler by \`controller.cron\`; a handler with no crons could never be reached. Duplicate cron strings across handlers throw with a clear \"already used by @scheduled 'X'\" message.
- **Codegen** (\`generate-workflow.ts\`): emits \`async scheduled(controller: ScheduledController, env: Env, ctx: ExecutionContext): Promise<void>\` with one \`case\` per cron, fallthrough to a single body per handler.
- **Adapter** (\`adapter.ts\`): new \`buildCronTriggers()\` unions annotation crons (declaration order) with \`deploymentConfig.cronTriggers\` and dedupes before passing to deploy → wrangler \`triggers.crons\`.

### Tests
- 10 parser cases (happy paths + 6 error paths)
- 3 codegen cases (single handler, multi handler, omission)
- 5 adapter cases for \`buildCronTriggers\`
- 2 obsolete \"unknown kind\" parser tests retargeted to \`@durable\` (since \`@scheduled\` is now valid)

Total: +18 tests, 447 passing.

## Test plan
- [ ] Define a workflow whose triggerCode contains \`@scheduled function nightly(...)\` with \`@crons [\"0 2 * * *\"]\`. Generated worker has \`async scheduled\` with \`case \"0 2 * * *\":\`. Wrangler config shows \`triggers.crons = [\"0 2 * * *\"]\`.
- [ ] Two scheduled handlers with disjoint crons — both cases appear in the switch, both crons land in wrangler.
- [ ] Two scheduled handlers with the SAME cron string — parser rejects with the \"already used by\" message before deploy.
- [ ] \`@scheduled\` without \`@crons\` — parser rejects with \"missing required @crons\".
- [ ] Combine \`@fetch\` + \`@queue\` + \`@scheduled\` in one workflow — all three handlers appear on the default export.
- [ ] Deployment config also lists a cron not in any annotation — both annotation crons and the deployment-config cron land in \`triggers.crons\`, deduped, annotations first.