### PR TITLE
fix: observability toggle generates legacy Logpush flag instead of Workers Logs & Traces

### DIFF
--- a/packages/provider-cloudflare/src/__tests__/config-schema.test.ts
+++ b/packages/provider-cloudflare/src/__tests__/config-schema.test.ts
@@ -113,6 +113,51 @@ describe('cloudflareDefaultDeploymentConfig', () => {
     expect(cloudflareDefaultDeploymentConfig.workersDev).toBe(true)
     expect(cloudflareDefaultDeploymentConfig.previewUrls).toBe(true)
   })
+
+  it('does not hardcode observability — falls back to WRANGLER_BASE_CONFIG', () => {
+    expect(cloudflareDefaultDeploymentConfig.observability).toBeUndefined()
+  })
+})
+
+describe('cloudflareDeploymentConfigSchema — observability toggle', () => {
+  it('maps boolean true to the full logs+traces config', () => {
+    const parsed = cloudflareDeploymentConfigSchema.safeParse({ observability: true })
+    expect(parsed.success).toBe(true)
+    if (!parsed.success) return
+    const obs = parsed.data.observability
+    expect(obs?.logs?.enabled).toBe(true)
+    expect(obs?.logs?.persist).toBe(true)
+    expect(obs?.logs?.invocation_logs).toBe(true)
+    expect(obs?.traces?.enabled).toBe(true)
+    expect(obs?.traces?.persist).toBe(true)
+    // Legacy top-level flag should be off — we use the new system
+    expect(obs?.enabled).toBe(false)
+  })
+
+  it('maps boolean false to a fully-disabled config', () => {
+    const parsed = cloudflareDeploymentConfigSchema.safeParse({ observability: false })
+    expect(parsed.success).toBe(true)
+    if (!parsed.success) return
+    const obs = parsed.data.observability
+    expect(obs?.logs?.enabled).toBe(false)
+    expect(obs?.traces?.enabled).toBe(false)
+  })
+
+  it('passes through an object config as-is', () => {
+    const parsed = cloudflareDeploymentConfigSchema.safeParse({
+      observability: { logs: { enabled: true, persist: false } },
+    })
+    expect(parsed.success).toBe(true)
+    if (!parsed.success) return
+    expect(parsed.data.observability?.logs?.persist).toBe(false)
+  })
+
+  it('accepts undefined observability (uses WRANGLER_BASE_CONFIG defaults)', () => {
+    const parsed = cloudflareDeploymentConfigSchema.safeParse({})
+    expect(parsed.success).toBe(true)
+    if (!parsed.success) return
+    expect(parsed.data.observability).toBeUndefined()
+  })
 })
 
 describe('cloudflareDeploymentConfigUiSchema', () => {

--- a/packages/provider-cloudflare/src/adapter.ts
+++ b/packages/provider-cloudflare/src/adapter.ts
@@ -113,9 +113,12 @@ export class CloudflareWorkflowsAdapter implements WorkflowProvider, LocalDevPro
     if (c.limits?.cpuMs) {
       preview.limits = { cpu_ms: c.limits.cpuMs }
     }
-    if (c.observability) {
-      preview.observability = c.observability
-    }
+    // Always show the full observability config in the preview — merge
+    // WRANGLER_BASE_CONFIG as the base so the Review step reflects what
+    // actually gets deployed, with any Configure-step overrides on top.
+    preview.observability = c.observability
+      ? { ...WRANGLER_BASE_CONFIG.observability, ...c.observability }
+      : { ...WRANGLER_BASE_CONFIG.observability }
     if (c.logpush) {
       preview.logpush = true
     }

--- a/packages/provider-cloudflare/src/config-schema.ts
+++ b/packages/provider-cloudflare/src/config-schema.ts
@@ -62,14 +62,47 @@ export const cloudflareDeploymentConfigSchema = z
       )
       .optional(),
 
-    // Observability (boolean true → { enabled: true } from UI toggle)
+    // Observability — the UI exposes a simple boolean toggle.
+    //   true  → full logs + traces config (persist, invocation_logs, head_sampling_rate)
+    //   false → everything disabled
+    //   object → passed through as-is for advanced overrides
+    // When undefined (not set) the adapter falls back to WRANGLER_BASE_CONFIG.observability.
     observability: z
       .preprocess(
-        (v) => (v === true ? { enabled: true } : v === false ? undefined : v),
+        (v) => {
+          if (v === true) {
+            return {
+              enabled: false,
+              head_sampling_rate: 1,
+              logs: { enabled: true, head_sampling_rate: 1, persist: true, invocation_logs: true },
+              traces: { enabled: true, persist: true, head_sampling_rate: 1 },
+            }
+          }
+          if (v === false) {
+            return { enabled: false, logs: { enabled: false }, traces: { enabled: false } }
+          }
+          return v
+        },
         z
           .object({
-            enabled: z.boolean(),
+            enabled: z.boolean().optional(),
+            head_sampling_rate: z.number().min(0).max(1).optional(),
             headSamplingRate: z.number().min(0).max(1).optional(),
+            logs: z
+              .object({
+                enabled: z.boolean().optional(),
+                head_sampling_rate: z.number().min(0).max(1).optional(),
+                persist: z.boolean().optional(),
+                invocation_logs: z.boolean().optional(),
+              })
+              .optional(),
+            traces: z
+              .object({
+                enabled: z.boolean().optional(),
+                persist: z.boolean().optional(),
+                head_sampling_rate: z.number().min(0).max(1).optional(),
+              })
+              .optional(),
           })
           .optional(),
       )
@@ -89,7 +122,8 @@ export type CloudflareDeploymentConfig = z.infer<typeof cloudflareDeploymentConf
 export const cloudflareDefaultDeploymentConfig: CloudflareDeploymentConfig = {
   workersDev: true,
   previewUrls: true,
-  observability: { enabled: true },
+  // observability is intentionally omitted here — the full nested
+  // logs/traces config comes from WRANGLER_BASE_CONFIG in wrangler-config.ts
 }
 
 export const cloudflareDeploymentConfigUiSchema: DeploymentConfigUiSchema = {
@@ -184,7 +218,7 @@ export const cloudflareDeploymentConfigUiSchema: DeploymentConfigUiSchema = {
           path: 'observability',
           label: 'Enable observability',
           widget: 'boolean',
-          help: 'Send Workers Trace Events for logs and metrics.',
+          help: 'Enable Workers Logs and Traces with persistence and full sampling (logs, traces, invocation events).',
         },
         {
           path: 'logpush',

--- a/packages/provider-cloudflare/src/deploy/deployer.ts
+++ b/packages/provider-cloudflare/src/deploy/deployer.ts
@@ -82,7 +82,22 @@ export interface DeployOptions {
   cronTriggers?: string[]
   placement?: { mode: string }
   limits?: { cpuMs?: number }
-  observability?: { enabled: boolean; headSamplingRate?: number }
+  observability?: {
+    enabled?: boolean
+    head_sampling_rate?: number
+    headSamplingRate?: number
+    logs?: {
+      enabled?: boolean
+      head_sampling_rate?: number
+      persist?: boolean
+      invocation_logs?: boolean
+    }
+    traces?: {
+      enabled?: boolean
+      persist?: boolean
+      head_sampling_rate?: number
+    }
+  }
   logpush?: boolean
   /** Per-queue consumer settings; emitted as `queues.consumers[]` in wrangler.json. */
   queueConsumers?: Array<{

--- a/packages/provider-cloudflare/src/wrangler-config.ts
+++ b/packages/provider-cloudflare/src/wrangler-config.ts
@@ -5,7 +5,21 @@ import type { SubScriptBinding } from './codegen/generators/sub-script.js'
 export const WRANGLER_BASE_CONFIG = {
   compatibility_date: '2025-04-01',
   compatibility_flags: ['nodejs_compat'],
-  observability: { enabled: true },
+  observability: {
+    enabled: false,
+    head_sampling_rate: 1,
+    logs: {
+      enabled: true,
+      head_sampling_rate: 1,
+      persist: true,
+      invocation_logs: true,
+    },
+    traces: {
+      enabled: true,
+      persist: true,
+      head_sampling_rate: 1,
+    },
+  },
 } as const
 
 export interface WranglerWorkflowConfig {
@@ -42,7 +56,21 @@ export interface WranglerWorkflowConfig {
   cronTriggers?: string[]
   placement?: { mode: string }
   limits?: { cpuMs?: number }
-  observability?: { enabled: boolean; headSamplingRate?: number }
+  observability?: {
+    enabled?: boolean
+    head_sampling_rate?: number
+    logs?: {
+      enabled?: boolean
+      head_sampling_rate?: number
+      persist?: boolean
+      invocation_logs?: boolean
+    }
+    traces?: {
+      enabled?: boolean
+      persist?: boolean
+      head_sampling_rate?: number
+    }
+  }
   logpush?: boolean
   /**
    * Per-queue consumer settings — populated by the adapter from `@queue function NAME`


### PR DESCRIPTION
## Summary

The **Enable observability** toggle on the deployment Configure step was mapping boolean `true` to `{ "enabled": true }`, which is the legacy Cloudflare Logpush flag. Without a separately configured Logpush destination this has no effect, and it does **not** enable Workers Logs or Workers Traces (the modern observability system).

## Steps to Reproduce

1. Open any workflow and click **Deploy**
2. Complete the **Connection** step
3. On the **Configure** step, toggle **Enable observability** ON
4. Click **Next** to the **Review** step
5. Inspect the generated `wrangler.json`

## Actual Behavior

```json
{ "observability": { "enabled": true } }
```

This is the legacy Logpush flag — does nothing without a Logpush destination configured. Workers Traces are not enabled.

## Expected Behavior

```json
{
  "observability": {
    "enabled": false,
    "head_sampling_rate": 1,
    "logs": { "enabled": true, "persist": true, "invocation_logs": true, "head_sampling_rate": 1 },
    "traces": { "enabled": true, "persist": true, "head_sampling_rate": 1 }
  }
}
```

## Changes

- **`config-schema.ts`**: preprocess now maps `true` → full logs+traces config, `false` → all disabled. Removes hardcoded `observability: { enabled: true }` from `cloudflareDefaultDeploymentConfig` so new deployments fall back to `WRANGLER_BASE_CONFIG`.
- **`wrangler-config.ts`**: expand `WRANGLER_BASE_CONFIG` and `WranglerWorkflowConfig` type to support the full nested `logs`/`traces` shape.
- **`deploy/deployer.ts`**: expand `DeployOptions` observability type to match.
- **`adapter.ts`**: `buildDeploymentConfigPreview` now merges `WRANGLER_BASE_CONFIG` so the Review step shows the actual config that will be deployed.
- **`config-schema.test.ts`**: adds 4 tests covering the boolean toggle mapping.

## Environment

- OS: macOS
- Node: 22 / pnpm 9.15.4
- AwaitStep: 1.4.12