### PR TITLE
fix: cf script codegen, dashboard URL, and responsive canvas toolbar

### DIFF
--- a/apps/web/src/components/canvas/editor-toolbar.tsx
+++ b/apps/web/src/components/canvas/editor-toolbar.tsx
@@ -60,9 +60,12 @@ function SaveStatusIndicator({
 }) {
   if (isSaving) {
     return (
-      <span className="inline-flex items-center gap-1 text-xs text-muted-foreground">
+      <span
+        className="inline-flex items-center gap-1 text-xs text-muted-foreground"
+        title="Saving…"
+      >
         <Loader2 className="h-3 w-3 animate-spin" />
-        Saving…
+        <span className="hidden sm:inline">Saving…</span>
       </span>
     )
   }
@@ -73,15 +76,18 @@ function SaveStatusIndicator({
         title={autoSaveError}
       >
         <AlertCircle className="h-3 w-3" />
-        Couldn&apos;t auto-save
+        <span className="hidden sm:inline">Couldn&apos;t auto-save</span>
       </span>
     )
   }
   if (isDirty) {
     return (
-      <span className="inline-flex items-center gap-1 text-xs text-status-warning">
+      <span
+        className="inline-flex items-center gap-1 text-xs text-status-warning"
+        title="Unsaved changes"
+      >
         <Circle className="h-2 w-2 fill-status-warning text-status-warning" />
-        Unsaved
+        <span className="hidden sm:inline">Unsaved</span>
       </span>
     )
   }
@@ -92,7 +98,7 @@ function SaveStatusIndicator({
         title={`Saved at ${lastSavedAt.toLocaleTimeString()}`}
       >
         <Check className="h-3 w-3 text-status-success" />
-        Saved
+        <span className="hidden sm:inline">Saved</span>
       </span>
     )
   }
@@ -129,34 +135,36 @@ export function EditorToolbar({
   const router = useRouter()
 
   return (
-    <header className="relative z-20 flex h-14 shrink-0 items-center justify-between border-b border-border bg-card px-4">
-      <div className="flex items-center gap-2">
+    <header className="relative z-20 flex h-14 shrink-0 items-center justify-between gap-2 border-b border-border bg-card px-3 sm:px-4">
+      <div className="flex min-w-0 items-center gap-1 sm:gap-2">
         <Button
           variant="ghost"
           size="icon"
-          className="h-8 w-8 text-muted-foreground hover:text-foreground/80"
+          className="h-8 w-8 shrink-0 text-muted-foreground hover:text-foreground/80"
           onClick={() => router.history.back()}
         >
           <ArrowLeft className="h-4 w-4" />
         </Button>
-        <div className="h-5 w-px bg-muted/70" />
-        <div className="flex items-center gap-2 px-1">
-          <span className="text-sm font-semibold text-foreground">{workflowName}</span>
+        <div className="hidden h-5 w-px shrink-0 bg-muted/70 sm:block" />
+        <div className="flex min-w-0 items-center gap-1.5 px-1 sm:gap-2">
+          <span className="max-w-[120px] truncate text-sm font-semibold text-foreground sm:max-w-[200px] md:max-w-[260px] lg:max-w-none">
+            {workflowName}
+          </span>
           {kind === 'script' && (
             <span
-              className="inline-flex items-center rounded border border-border bg-muted/40 px-1.5 py-0.5 text-[10px] font-medium uppercase tracking-wide text-muted-foreground"
+              className="hidden shrink-0 items-center rounded border border-border bg-muted/40 px-1.5 py-0.5 text-[10px] font-medium uppercase tracking-wide text-muted-foreground sm:inline-flex"
               title="Stateless fetch-only Worker — runs synchronously, no sleeps or waits"
             >
               Function
             </span>
           )}
           {!isNew && currentVersion > 0 && (
-            <span className="rounded bg-muted/60 px-1.5 py-0.5 text-xs font-medium text-muted-foreground/60">
+            <span className="shrink-0 rounded bg-muted/60 px-1.5 py-0.5 text-xs font-medium text-muted-foreground/60">
               v{currentVersion}
             </span>
           )}
           {nodeCount > 0 && (
-            <span className="rounded bg-primary/10 px-1.5 py-0.5 text-xs font-medium text-primary">
+            <span className="hidden shrink-0 rounded bg-primary/10 px-1.5 py-0.5 text-xs font-medium text-primary md:inline-flex">
               {nodeCount} node{nodeCount !== 1 ? 's' : ''}
             </span>
           )}
@@ -164,11 +172,12 @@ export function EditorToolbar({
             <Link
               to="/workflows/$workflowId/deployments"
               params={{ workflowId }}
-              className={`rounded px-1.5 py-0.5 text-xs font-medium transition-colors ${
+              className={cn(
+                'hidden shrink-0 rounded px-1.5 py-0.5 text-xs font-medium transition-colors md:inline-block',
                 hasUndeployedChanges
                   ? 'bg-status-warning/10 text-status-warning hover:bg-status-warning/20'
-                  : 'bg-status-success/10 text-status-success hover:bg-status-success/20'
-              }`}
+                  : 'bg-status-success/10 text-status-success hover:bg-status-success/20',
+              )}
             >
               {hasUndeployedChanges
                 ? `deployed v${deployedVersion ?? '?'} · v${currentVersion} unsaved`
@@ -184,15 +193,16 @@ export function EditorToolbar({
         </div>
       </div>
 
-      <div className="flex items-center gap-1.5">
+      <div className="flex shrink-0 items-center gap-1 sm:gap-1.5">
         {readOnly ? (
           <>
-            <span className="rounded bg-muted/70 px-2 py-1 text-xs font-medium text-muted-foreground">
+            <span className="hidden rounded bg-muted/70 px-2 py-1 text-xs font-medium text-muted-foreground sm:inline-block">
               Read-only{readOnlyVersion ? ` · v${readOnlyVersion}` : ''}
             </span>
             <Link to="/workflows/$workflowId/canvas" params={{ workflowId }}>
               <Button size="sm" variant="outline" className="h-8 gap-1.5 px-3 text-xs">
-                Back to latest
+                <span className="hidden sm:inline">Back to latest</span>
+                <span className="sm:hidden">Latest</span>
               </Button>
             </Link>
           </>
@@ -203,8 +213,9 @@ export function EditorToolbar({
               size="sm"
               onClick={onSave}
               disabled={isSaving || !isDirty}
+              title="Save"
               className={cn(
-                'h-8 gap-1.5 px-2.5',
+                'h-8 gap-1.5 px-2 md:px-2.5',
                 isDirty ? 'text-foreground/70 hover:text-foreground' : 'text-muted-foreground/60',
               )}
             >
@@ -213,27 +224,30 @@ export function EditorToolbar({
               ) : (
                 <Save className="h-3.5 w-3.5" />
               )}
-              <span className="text-xs">Save</span>
+              <span className="hidden text-xs md:inline">Save</span>
             </Button>
             <Button
               variant="ghost"
               size="sm"
               onClick={onToggleSettings}
+              title="Settings"
               className={cn(
+                'hidden h-8 gap-1.5 px-2 sm:inline-flex md:px-2.5',
                 showSettings
                   ? 'bg-muted/70 text-foreground'
                   : 'text-muted-foreground hover:text-foreground/70',
               )}
             >
               <Settings2 className="h-3.5 w-3.5" />
-              <span className="text-xs">Settings</span>
+              <span className="hidden text-xs md:inline">Settings</span>
             </Button>
             <Button
               variant="ghost"
               size="sm"
               onClick={onToggleEditor}
+              title={showEditor ? 'Hide editor' : 'Show editor'}
               className={cn(
-                'h-8 gap-1.5 px-2.5',
+                'hidden h-8 gap-1.5 px-2 sm:inline-flex md:px-2.5',
                 showEditor
                   ? 'bg-muted/70 text-foreground'
                   : 'text-muted-foreground hover:text-foreground/70',
@@ -244,54 +258,63 @@ export function EditorToolbar({
               ) : (
                 <Code2 className="h-3.5 w-3.5" />
               )}
-              <span className="text-xs">Editor</span>
+              <span className="hidden text-xs md:inline">Editor</span>
             </Button>
             {isNew && kind !== 'script' && (
               <Button
                 variant="ghost"
                 size="sm"
-                className="h-8 gap-1.5 px-2.5 text-muted-foreground hover:text-foreground/70"
+                title="Templates"
+                className="hidden h-8 gap-1.5 px-2 text-muted-foreground hover:text-foreground/70 sm:inline-flex md:px-2.5"
                 onClick={onOpenTemplatePicker}
               >
                 <LayoutTemplate className="h-3.5 w-3.5" />
-                <span className="text-xs">Templates</span>
+                <span className="hidden text-xs md:inline">Templates</span>
               </Button>
             )}
             {onExport && (
               <Button
                 variant="ghost"
                 size="sm"
-                className="h-8 gap-1.5 px-2.5 text-muted-foreground hover:text-foreground/70"
+                title="Export"
+                className="hidden h-8 gap-1.5 px-2 text-muted-foreground hover:text-foreground/70 sm:inline-flex md:px-2.5"
                 onClick={onExport}
               >
                 <Download className="h-3.5 w-3.5" />
-                <span className="text-xs">Export</span>
+                <span className="hidden text-xs md:inline">Export</span>
               </Button>
             )}
-            <div className="h-5 w-px bg-muted/70" />
+            <div className="hidden h-5 w-px shrink-0 bg-muted/70 sm:block" />
             <Button
               variant="ghost"
               size="sm"
-              className="h-8 gap-1.5 px-2.5 text-muted-foreground hover:text-foreground/80"
+              title="Test"
+              className="h-8 gap-1.5 px-2 text-muted-foreground hover:text-foreground/80 md:px-2.5"
               onClick={onTest}
             >
               <Play className="h-3.5 w-3.5" />
-              <span className="text-xs">Test</span>
+              <span className="hidden text-xs md:inline">Test</span>
             </Button>
             {onTestLocally && (
               <Button
                 variant="ghost"
                 size="sm"
-                className="h-8 gap-1.5 px-2.5 text-muted-foreground hover:text-foreground/80"
+                title="Local test"
+                className="hidden h-8 gap-1.5 px-2 text-muted-foreground hover:text-foreground/80 sm:inline-flex md:px-2.5"
                 onClick={onTestLocally}
               >
                 <Terminal className="h-3.5 w-3.5" />
-                <span className="text-xs">Local</span>
+                <span className="hidden text-xs md:inline">Local</span>
               </Button>
             )}
-            <Button size="sm" className="h-8 gap-1.5 px-3" onClick={onDeploy}>
+            <Button
+              size="sm"
+              className="h-8 gap-1.5 px-2.5 md:px-3"
+              onClick={onDeploy}
+              title="Deploy"
+            >
               <Rocket className="h-3.5 w-3.5" />
-              <span className="text-xs">Deploy</span>
+              <span className="hidden text-xs sm:inline">Deploy</span>
             </Button>
           </>
         )}

--- a/packages/provider-cloudflare/src/__tests__/codegen/generate-script.test.ts
+++ b/packages/provider-cloudflare/src/__tests__/codegen/generate-script.test.ts
@@ -180,7 +180,11 @@ describe('generateScript', () => {
     expect(code).not.toContain('WORKFLOW: Workflow')
   })
 
-  it('a non-exported, unreferenced sub_workflow becomes a clean bare `await`', () => {
+  it('auto-exports a sub_workflow handle even without EXPORT_ prefix', () => {
+    // sub_workflow is a result-producer node — its value (the WorkflowInstance
+    // handle) is almost always what the user wants to surface (instance.id,
+    // status(), etc). Treated as implicitly exported so the const survives
+    // post-processing and the handle lands on `graph.<name>`.
     const ir = makeScript([
       {
         id: 'send-auth-email',
@@ -197,12 +201,53 @@ describe('generateScript', () => {
       },
     ])
     const code = generateScript(ir)
-    // The const-strip rewrite must not leave a bare object literal at
-    // statement position. Result: a single `await env.SEND_MAIL.create(...)`.
-    expect(code).toContain('await env.SEND_MAIL.create({')
-    expect(code).not.toMatch(/^\s*\{ instanceId:/m)
-    expect(code).not.toContain('const send_auth_email')
-    expect(code).toContain('return {};')
+    expect(code).toContain('const send_auth_email = await env.SEND_MAIL.create({')
+    expect(code).toContain('return { send_auth_email };')
+  })
+
+  it('auto-exports an http_request response even without EXPORT_ prefix', () => {
+    // http_request is a result-producer node — its purpose is to make a
+    // call and surface the JSON response. The response must land on
+    // `graph.<name>` without forcing the user to learn the EXPORT_
+    // convention; otherwise the entire request silently disappears.
+    const ir = makeScript([
+      {
+        id: 'fetch-rates',
+        type: 'http_request',
+        name: 'exchange_rate',
+        position: { x: 0, y: 0 },
+        version: '1.0.0',
+        provider: 'cloudflare',
+        data: {
+          url: 'https://example.com/rates',
+          method: 'GET',
+        },
+      },
+    ])
+    const code = generateScript(ir)
+    expect(code).toContain('const exchange_rate = await fetch(')
+    expect(code).toContain('return { exchange_rate };')
+  })
+
+  it('auto-exports a sub_script response even without EXPORT_ prefix', () => {
+    const ir = makeScript([
+      {
+        id: 'call-pricing',
+        type: 'sub_script',
+        name: 'pricing',
+        position: { x: 0, y: 0 },
+        version: '1.0.0',
+        provider: 'cloudflare',
+        data: {
+          workerName: 'pricing-svc',
+          method: 'GET',
+          url: 'https://pricing-svc.example/quote',
+        },
+      },
+    ])
+    const code = generateScript(ir)
+    expect(code).toContain('const pricing = await env.PRICING_SVC.fetch(')
+    expect(code).toContain('return { pricing };')
   })
 
   it('emits a sub_workflow forward as a fire-and-forget binding call', () => {

--- a/packages/provider-cloudflare/src/adapter.ts
+++ b/packages/provider-cloudflare/src/adapter.ts
@@ -389,7 +389,7 @@ export class CloudflareWorkflowsAdapter implements WorkflowProvider, LocalDevPro
       success: true,
       deploymentId: result.workerName,
       url: result.workerUrl,
-      dashboardUrl: `https://dash.cloudflare.com/${accountId}/workers/services/view/${result.workerName}`,
+      dashboardUrl: `https://dash.cloudflare.com/${accountId}/workers/services/view/${result.workerName}/production`,
     }
   }
 

--- a/packages/provider-cloudflare/src/codegen/generate-script.ts
+++ b/packages/provider-cloudflare/src/codegen/generate-script.ts
@@ -167,8 +167,15 @@ export function generateScript(
   //      the call becomes a bare `await ...;`.
   //   4. Not exported, referenced elsewhere: keep `const X = ...` (downstream
   //      nodes need the var) but don't include in return.
+  //
+  // Result-producer node types are implicitly exported (no EXPORT_ needed):
+  // their entire purpose is to surface a value (HTTP response, sub-worker
+  // output, sub-workflow handle). A bare `await fetch(...)` with the result
+  // thrown away is almost never what the user intends.
+  //
   // Must run before `clearVarNameMap` so `varName(node.id)` resolves to the
   // same name the per-node generators emitted.
+  const AUTO_EXPORT_TYPES = new Set(['http_request', 'sub_workflow', 'sub_script'])
   const exportedVarNames: string[] = []
   const hoistedVarNames: string[] = []
   for (const node of resolvedIR.nodes) {
@@ -177,7 +184,7 @@ export function generateScript(
     const m = declRe.exec(graphBody)
     if (!m) continue
 
-    const exported = isExportedName(node.name)
+    const exported = isExportedName(node.name) || AUTO_EXPORT_TYPES.has(node.type)
     const isNested = m[1].length > 0
     const refMatches = [...graphBody.matchAll(new RegExp(`\\b${v}\\b`, 'g'))]
     const isReferencedElsewhere = refMatches.length > 1


### PR DESCRIPTION
## Summary

Three unrelated fixes bundled into one PR:

1. **Worker dashboard URL** lands on the `/production` deployment detail view instead of the service summary, so post-deploy clicks go straight to logs/metrics.
2. **Script codegen** auto-exports result-producer node types (`http_request`, `sub_workflow`, `sub_script`) without requiring an `EXPORT_` prefix. Their bound const now survives post-processing and the value lands on `graph.<name>` — previously the const-strip rewrite silently reduced them to a bare \`await\` and discarded the result.
3. **Canvas editor toolbar** is now responsive. The ~1200px-wide header (back arrow, name, five chips, eight buttons) collapsed badly on tablet and phone widths; viewport-stepped truncation, label hiding, and breakpoint-based visibility tame it.

## Commits

1. \`fix(provider-cloudflare): link Worker dashboard URL to /production view\` — 1-line URL change in adapter.ts.
2. \`fix(provider-cloudflare): auto-export result-producer node types in scripts\` — adds an \`AUTO_EXPORT_TYPES\` set; 1 existing test rewritten + 2 new sibling tests.
3. \`fix(canvas): responsive editor toolbar header\` — single-file CSS-only change.

## Toolbar breakpoint behavior

| Viewport | Left chips kept | Right buttons kept |
|---|---|---|
| **<640px** | name (≤120px) · editing v · save indicator (icon) | Save · Test · Deploy (icons only) |
| **640–767px** | + Function pill, save indicator text | + Settings · Editor · Templates · Export · Local (icon-only) |
| **≥768px** | + N nodes pill · deployed status badge | + button text labels |

## Test plan

- [x] \`pnpm build\` — green
- [x] \`pnpm lint\` — clean
- [x] \`pnpm test\` — 454/454 provider-cloudflare (+2 new auto-export tests)
- [x] \`tsc --noEmit\` (web) — clean
- [ ] Browser:
  - Deploy a Worker, click the dashboard link from the result panel → lands on \`/workers/services/view/<name>/production\`
  - Create a script with a single \`http_request\` node named (without \`EXPORT_\` prefix), deploy, invoke → response surfaces on \`graph.<name>\` instead of vanishing
  - Resize a canvas page from desktop down through 1280/1024/768/640/375px — toolbar should remain on one row without overflow at every step; icon-only buttons retain hover titles