### PR TITLE
fix(web): use SSR-safe storage in theme-store

### DIFF
--- a/apps/web/src/stores/theme-store.ts
+++ b/apps/web/src/stores/theme-store.ts
@@ -1,5 +1,6 @@
 import { create } from 'zustand'
 import { persist, createJSONStorage } from 'zustand/middleware'
+import { browserStorage } from './ssr-safe-storage'
 
 export type Theme = 'dark' | 'light'
 
@@ -14,6 +15,6 @@ export const useThemeStore = create<ThemeState>()(
       theme: 'dark',
       setTheme: (theme) => set({ theme }),
     }),
-    { name: 'awaitstep-theme', storage: createJSONStorage(() => localStorage) },
+    { name: 'awaitstep-theme', storage: createJSONStorage(() => browserStorage()) },
   ),
 )


### PR DESCRIPTION
## Summary

Fixes \`Cannot read properties of undefined (reading 'setState')\` on the home page of the Cloudflare-deployed web app.

\`theme-store\` was the only persisted zustand store passing bare \`localStorage\` to \`createJSONStorage\` — every other persisted store in \`apps/web/src/stores/\` already routes through \`browserStorage()\` from \`ssr-safe-storage.ts\` for exactly this reason.

On the Cloudflare Workers SSR pass there is no \`localStorage\` global, so the persist middleware's storage getter hit a \`ReferenceError\` during module init. That crashed the SSR render of the root layout (theme-store is consumed in \`ThemeScript\`, which renders inside \`__root.tsx\` on every route), producing a malformed hydration payload — and downstream code reading \`.setState\` on the now-undefined store blew up on the client.

## The fix

One-line change in \`apps/web/src/stores/theme-store.ts\`:

\`\`\`diff
-import { persist, createJSONStorage } from 'zustand/middleware'
+import { persist, createJSONStorage } from 'zustand/middleware'
+import { browserStorage } from './ssr-safe-storage'

-    { name: 'awaitstep-theme', storage: createJSONStorage(() => localStorage) },
+    { name: 'awaitstep-theme', storage: createJSONStorage(() => browserStorage()) },
\`\`\`

\`browserStorage()\` returns a no-op shim on the server and \`window.localStorage\` in the browser, matching what \`org-store\`, \`font-store\`, and \`onboarding-store\` already do.

## Test plan

- [x] \`pnpm --filter @awaitstep/web build\` — green
- [x] \`pnpm --filter @awaitstep/web lint\` — clean
- [x] \`pnpm --filter @awaitstep/web type-check\` — clean
- [ ] Deploy to Cloudflare and confirm the home page loads without the \`Cannot read properties of undefined (reading 'setState')\` console error
- [ ] Verify theme toggle still works (persisted to localStorage on the client)