### PR TITLE
docs: note kanban pipeline wiring

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+- Kanban pipeline is wired.
+
 ## [1.4.6](https://github.com/awaitstep/awaitstep/compare/v1.4.5-beta.0...v1.4.6) (2026-04-12)
 
 


### PR DESCRIPTION
## Summary
- Add a one-line CHANGELOG entry noting that the kanban pipeline is wired.

## Test Plan
- Not run (docs-only changelog entry).